### PR TITLE
5 time based anomaly durations

### DIFF
--- a/emulator.go
+++ b/emulator.go
@@ -74,8 +74,7 @@ type TemperatureEmulation struct {
 	InstantaneousAnomalyMagnitude   float64
 
 	// trend anomalies
-	IsTrendAnomaly bool
-	//TODO replace to timestamps for duration instead of steps
+	IsTrendAnomaly        bool
 	TrendAnomalyLength    int
 	TrendAnomalyIndex     int
 	TrendAnomalyMagnitude float64

--- a/emulator.go
+++ b/emulator.go
@@ -210,6 +210,43 @@ func (e *Emulator) Step() {
 	}
 }
 
+// Step performs one iteration of the waveform generation
+func (e *Emulator) Time_base_duration_loop(startTime int64, duration int64) {
+	var currentTime int64
+	for continue_flag := true; continue_flag; continue_flag = (currentTime - startTime) < duration {
+
+		currentTime = time.Now().Unix()
+		f := e.Fnom + e.Fdeviation
+
+		if e.fDeviationRemainingSamples > 0 {
+			e.fDeviationRemainingSamples--
+			if e.fDeviationRemainingSamples == 0 {
+				e.Fdeviation = 0.0
+			}
+		}
+
+		if e.V != nil {
+			e.V.stepThreePhase(e.r, f, e.Ts, e.SmpCnt)
+		}
+		if e.I != nil {
+			e.I.stepThreePhase(e.r, f, e.Ts, e.SmpCnt)
+		}
+		if e.T != nil {
+			e.T.stepTemperature(e.r, e.Ts)
+		}
+		if e.Sag != nil {
+			e.Sag.stepSag(e.r)
+		}
+
+		e.SmpCnt++
+		if int(e.SmpCnt) >= e.SamplingRate {
+			e.SmpCnt = 0
+		}
+
+	}
+
+}
+
 func (t *TemperatureEmulation) stepTemperature(r *rand.Rand, Ts float64) {
 	varyingT := t.MeanTemperature * (1 + t.ModulationMag*math.Cos(1000.0*Ts))
 

--- a/emulator.go
+++ b/emulator.go
@@ -74,7 +74,8 @@ type TemperatureEmulation struct {
 	InstantaneousAnomalyMagnitude   float64
 
 	// trend anomalies
-	IsTrendAnomaly        bool
+	IsTrendAnomaly bool
+	//TODO replace to timestamps for duration instead of steps
 	TrendAnomalyLength    int
 	TrendAnomalyIndex     int
 	TrendAnomalyMagnitude float64

--- a/emulator.go
+++ b/emulator.go
@@ -80,7 +80,10 @@ type TemperatureEmulation struct {
 	TrendAnomalyIndex     int
 	TrendAnomalyMagnitude float64
 
-	IsRisingTrendAnomaly bool
+	TrendAnomalyTimeStart    int64
+	TrendAnomalyTimeCurrent  int64
+	TrendAnomalyTimeDuration int64
+	IsRisingTrendAnomaly     bool
 
 	T float64
 }

--- a/emulator.go
+++ b/emulator.go
@@ -195,7 +195,10 @@ func (e *Emulator) Step() {
 		e.I.stepThreePhase(e.r, f, e.Ts, e.SmpCnt)
 	}
 	if e.T != nil {
-		e.T.stepTemperature(e.r, e.Ts)
+		e.T.TrendAnomalyTimeCurrent = time.Now().Unix()
+		if (e.T.TrendAnomalyTimeCurrent - e.T.TrendAnomalyTimeStart) < e.T.TrendAnomalyTimeDuration {
+			e.T.stepTemperature(e.r, e.Ts)
+		}
 	}
 	if e.Sag != nil {
 		e.Sag.stepSag(e.r)

--- a/emulator.go
+++ b/emulator.go
@@ -211,8 +211,9 @@ func (e *Emulator) Step() {
 }
 
 // Step performs one iteration of the waveform generation
-func (e *Emulator) Time_base_duration_loop(startTime int64, duration int64) {
+func (e *Emulator) Time_base_duration_loop(startTime int64, duration int64) []float64 {
 	var currentTime int64
+	var results []float64
 	for continue_flag := true; continue_flag; continue_flag = (currentTime - startTime) < duration {
 
 		currentTime = time.Now().Unix()
@@ -242,9 +243,9 @@ func (e *Emulator) Time_base_duration_loop(startTime int64, duration int64) {
 		if int(e.SmpCnt) >= e.SamplingRate {
 			e.SmpCnt = 0
 		}
-
+		results = append(results, e.T.T)
 	}
-
+	return results
 }
 
 func (t *TemperatureEmulation) stepTemperature(r *rand.Rand, Ts float64) {

--- a/emulator.go
+++ b/emulator.go
@@ -75,13 +75,10 @@ type TemperatureEmulation struct {
 
 	// trend anomalies
 	IsTrendAnomaly        bool
-	TrendAnomalyDuration  int
+	TrendAnomalyDuration  int // duration in seconds
 	TrendAnomalyIndex     int
 	TrendAnomalyMagnitude float64
 
-	// TrendAnomalyTimeStart    int64
-	// TrendAnomalyTimeCurrent  int64
-	// TrendAnomalyTimeDuration int64
 	IsRisingTrendAnomaly bool
 
 	T float64
@@ -195,11 +192,6 @@ func (e *Emulator) Step() {
 		e.I.stepThreePhase(e.r, f, e.Ts, e.SmpCnt)
 	}
 	if e.T != nil {
-		// e.T.TrendAnomalyTimeCurrent = time.Now().Unix()
-		// if (e.T.TrendAnomalyTimeCurrent - e.T.TrendAnomalyTimeStart) < e.T.TrendAnomalyTimeDuration {
-
-		// }
-
 		e.T.stepTemperature(e.r, e.Ts)
 	}
 	if e.Sag != nil {
@@ -212,51 +204,11 @@ func (e *Emulator) Step() {
 	}
 }
 
-// // Step performs one iteration of the waveform generation
-// func (e *Emulator) Time_base_duration_loop(startTime int64, duration int64) []float64 {
-// 	var currentTime int64
-// 	var results []float64
-// 	for continue_flag := true; continue_flag; continue_flag = (currentTime - startTime) < duration {
-
-// 		currentTime = time.Now().Unix()
-// 		f := e.Fnom + e.Fdeviation
-
-// 		if e.fDeviationRemainingSamples > 0 {
-// 			e.fDeviationRemainingSamples--
-// 			if e.fDeviationRemainingSamples == 0 {
-// 				e.Fdeviation = 0.0
-// 			}
-// 		}
-
-// 		if e.V != nil {
-// 			e.V.stepThreePhase(e.r, f, e.Ts, e.SmpCnt)
-// 		}
-// 		if e.I != nil {
-// 			e.I.stepThreePhase(e.r, f, e.Ts, e.SmpCnt)
-// 		}
-// 		if e.T != nil {
-// 			e.T.stepTemperature(e.r, e.Ts)
-// 		}
-// 		if e.Sag != nil {
-// 			e.Sag.stepSag(e.r)
-// 		}
-
-// 		e.SmpCnt++
-// 		if int(e.SmpCnt) >= e.SamplingRate {
-// 			e.SmpCnt = 0
-// 		}
-// 		results = append(results, e.T.T)
-// 	}
-// 	return results
-// }
-
 func (t *TemperatureEmulation) stepTemperature(r *rand.Rand, Ts float64) {
 	varyingT := t.MeanTemperature * (1 + t.ModulationMag*math.Cos(1000.0*Ts))
 
 	trendAnomalyDelta := 0.0
-
-	// was thinking to times the frequency in here for the anomaly steps
-	trendAnomalyStep := (t.TrendAnomalyMagnitude * 1 / float64(t.TrendAnomalyDuration)) * 1 / Ts
+	trendAnomalyStep := (t.TrendAnomalyMagnitude / float64(t.TrendAnomalyDuration)) * Ts
 
 	if t.IsTrendAnomaly == true {
 
@@ -266,8 +218,7 @@ func (t *TemperatureEmulation) stepTemperature(r *rand.Rand, Ts float64) {
 			trendAnomalyDelta = float64(t.TrendAnomalyIndex) * trendAnomalyStep * (-1.0)
 		}
 
-		// getting the amount of total steps and check the current index value
-		if t.TrendAnomalyIndex == int(float64(t.TrendAnomalyDuration)*1/Ts)-1 {
+		if t.TrendAnomalyIndex == int(float64(t.TrendAnomalyDuration)/Ts)-1 {
 			t.TrendAnomalyIndex = 0
 		} else {
 			t.TrendAnomalyIndex += 1

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -60,6 +60,8 @@ func createEmulator(samplingRate int, phaseOffsetDeg float64) *Emulator {
 		NoiseMax:                        0.01,
 		InstantaneousAnomalyMagnitude:   30,
 		InstantaneousAnomalyProbability: 0.01,
+		TrendAnomalyTimeStart:           time.Now().Unix(),
+		TrendAnomalyTimeDuration:        20,
 	}
 	return emu
 }

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -160,6 +160,27 @@ func TestTemperatureEmulationAnomalies_Trend_Time_Duration(t *testing.T) {
 	assert.True(t, mean(results) > emulator.T.MeanTemperature)
 }
 
+//TODO unit test for the new time duration loop
+func TestTemperatureEmulationAnomalies_Trend_Time_Duration_Test_B(t *testing.T) {
+	emulator := createEmulator(14400, 0)
+	emulator.T.IsTrendAnomaly = true
+	emulator.T.TrendAnomalyMagnitude = 30.0
+	emulator.T.TrendAnomalyLength = 1e3
+	emulator.T.IsRisingTrendAnomaly = true
+
+	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
+	emulator.T.TrendAnomalyTimeDuration = 20
+
+	var results []float64
+	for continue_flag := true; continue_flag; continue_flag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
+		emulator.Step()
+		results = append(results, emulator.T.T)
+		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
+	}
+
+	assert.True(t, mean(results) > emulator.T.MeanTemperature)
+}
+
 func TestTemperatureEmulationAnomalies_Decrease_Trend(t *testing.T) {
 	emulator := createEmulator(14400, 0)
 	emulator.T.IsTrendAnomaly = true

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -151,7 +151,7 @@ func TestTemperatureEmulationAnomalies_Trend_Time_Duration(t *testing.T) {
 	emulator.T.TrendAnomalyTimeDuration = 20
 
 	var results []float64
-	for continue_flag := true; continue_flag; continue_flag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
+	for continueFlag := true; continueFlag; continueFlag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
 		emulator.Step()
 		results = append(results, emulator.T.T)
 		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
@@ -172,7 +172,7 @@ func TestTemperatureEmulationAnomalies_Trend_Time_Duration_Test_B(t *testing.T) 
 	emulator.T.TrendAnomalyTimeDuration = 20
 
 	var results []float64
-	for continue_flag := true; continue_flag; continue_flag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
+	for continueFlag := true; continueFlag; continueFlag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
 		emulator.Step()
 		results = append(results, emulator.T.T)
 		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -172,11 +172,7 @@ func TestTemperatureEmulationAnomalies_Trend_Time_Duration_Test_B(t *testing.T) 
 	emulator.T.TrendAnomalyTimeDuration = 20
 
 	var results []float64
-	for continueFlag := true; continueFlag; continueFlag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
-		emulator.Step()
-		results = append(results, emulator.T.T)
-		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
-	}
+	results = emulator.Time_base_duration_loop(emulator.T.TrendAnomalyTimeStart, emulator.T.TrendAnomalyTimeDuration)
 
 	assert.True(t, mean(results) > emulator.T.MeanTemperature)
 }
@@ -194,6 +190,22 @@ func TestTemperatureEmulationAnomalies_Decrease_Trend(t *testing.T) {
 		results = append(results, emulator.T.T)
 		step += 1
 	}
+
+	assert.True(t, mean(results) < emulator.T.MeanTemperature)
+}
+
+func TestTemperatureEmulationAnomalies_Decrease_Trend_Time_Duration_Test_B(t *testing.T) {
+	emulator := createEmulator(14400, 0)
+	emulator.T.IsTrendAnomaly = true
+	emulator.T.TrendAnomalyMagnitude = 30.0
+	emulator.T.TrendAnomalyLength = 1e3
+	emulator.T.IsRisingTrendAnomaly = false
+
+	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
+	emulator.T.TrendAnomalyTimeDuration = 20
+
+	var results []float64
+	results = emulator.Time_base_duration_loop(emulator.T.TrendAnomalyTimeStart, emulator.T.TrendAnomalyTimeDuration)
 
 	assert.True(t, mean(results) < emulator.T.MeanTemperature)
 }

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -1,9 +1,9 @@
 package emulator
 
 import (
+	"fmt"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -60,8 +60,8 @@ func createEmulator(samplingRate int, phaseOffsetDeg float64) *Emulator {
 		NoiseMax:                        0.01,
 		InstantaneousAnomalyMagnitude:   30,
 		InstantaneousAnomalyProbability: 0.01,
-		TrendAnomalyTimeStart:           time.Now().Unix(),
-		TrendAnomalyTimeDuration:        20,
+		// TrendAnomalyTimeStart:           time.Now().Unix(),
+		// TrendAnomalyTimeDuration:        20,
 	}
 	return emu
 }
@@ -124,68 +124,71 @@ func TestTemperatureEmulationAnomalies_Anomalies(t *testing.T) {
 }
 
 func TestTemperatureEmulationAnomalies_Trend(t *testing.T) {
-	emulator := createEmulator(14400, 0)
+	emulator := createEmulator(100, 0)
 	emulator.T.IsTrendAnomaly = true
 	emulator.T.TrendAnomalyMagnitude = 30.0
-	emulator.T.TrendAnomalyLength = 1e3
+	emulator.T.TrendAnomalyDuration = 10
 	emulator.T.IsRisingTrendAnomaly = true
+
 	step := 0
 	var results []float64
-	for step < 1e4 {
+	//duration times frequency equals total steps?
+	for step < emulator.T.TrendAnomalyDuration*emulator.SamplingRate {
 		emulator.Step()
 		results = append(results, emulator.T.T)
 		step += 1
 	}
+	fmt.Println(step)
 
 	assert.True(t, mean(results) > emulator.T.MeanTemperature)
 }
 
-func TestTemperatureEmulationAnomalies_Trend_Time_Duration(t *testing.T) {
-	emulator := createEmulator(14400, 0)
-	emulator.T.IsTrendAnomaly = true
-	emulator.T.TrendAnomalyMagnitude = 30.0
-	emulator.T.TrendAnomalyLength = 1e3
-	emulator.T.IsRisingTrendAnomaly = true
+// func TestTemperatureEmulationAnomalies_Trend_Time_Duration(t *testing.T) {
+// 	emulator := createEmulator(14400, 0)
+// 	emulator.T.IsTrendAnomaly = true
+// 	emulator.T.TrendAnomalyMagnitude = 30.0
+// 	emulator.T.TrendAnomalyLength = 1e3
+// 	emulator.T.IsRisingTrendAnomaly = true
 
-	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
-	emulator.T.TrendAnomalyTimeDuration = 20
+// 	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
+// 	emulator.T.TrendAnomalyTimeDuration = 20
 
-	var results []float64
-	for continueFlag := true; continueFlag; continueFlag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
-		emulator.Step()
-		results = append(results, emulator.T.T)
-		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
-	}
+// 	var results []float64
+// 	for continueFlag := true; continueFlag; continueFlag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
+// 		emulator.Step()
+// 		results = append(results, emulator.T.T)
+// 		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
+// 	}
 
-	assert.True(t, mean(results) > emulator.T.MeanTemperature)
-}
+// 	assert.True(t, mean(results) > emulator.T.MeanTemperature)
+// }
 
 //TODO unit test for the new time duration loop
-func TestTemperatureEmulationAnomalies_Trend_Time_Duration_Test_B(t *testing.T) {
-	emulator := createEmulator(14400, 0)
-	emulator.T.IsTrendAnomaly = true
-	emulator.T.TrendAnomalyMagnitude = 30.0
-	emulator.T.TrendAnomalyLength = 1e3
-	emulator.T.IsRisingTrendAnomaly = true
+// func TestTemperatureEmulationAnomalies_Trend_Time_Duration_Test_B(t *testing.T) {
+// 	emulator := createEmulator(14400, 0)
+// 	emulator.T.IsTrendAnomaly = true
+// 	emulator.T.TrendAnomalyMagnitude = 30.0
+// 	emulator.T.TrendAnomalyLength = 1e3
+// 	emulator.T.IsRisingTrendAnomaly = true
 
-	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
-	emulator.T.TrendAnomalyTimeDuration = 20
+// 	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
+// 	emulator.T.TrendAnomalyTimeDuration = 20
 
-	var results []float64
-	results = emulator.Time_base_duration_loop(emulator.T.TrendAnomalyTimeStart, emulator.T.TrendAnomalyTimeDuration)
+// 	var results []float64
+// 	results = emulator.Time_base_duration_loop(emulator.T.TrendAnomalyTimeStart, emulator.T.TrendAnomalyTimeDuration)
 
-	assert.True(t, mean(results) > emulator.T.MeanTemperature)
-}
+// 	assert.True(t, mean(results) > emulator.T.MeanTemperature)
+// }
 
 func TestTemperatureEmulationAnomalies_Decrease_Trend(t *testing.T) {
-	emulator := createEmulator(14400, 0)
+	emulator := createEmulator(1, 0)
 	emulator.T.IsTrendAnomaly = true
 	emulator.T.TrendAnomalyMagnitude = 30.0
-	emulator.T.TrendAnomalyLength = 1e3
+	emulator.T.TrendAnomalyDuration = 10
 	emulator.T.IsRisingTrendAnomaly = false
 	step := 0
 	var results []float64
-	for step < 1e4 {
+	for step < 10 {
 		emulator.Step()
 		results = append(results, emulator.T.T)
 		step += 1
@@ -194,41 +197,41 @@ func TestTemperatureEmulationAnomalies_Decrease_Trend(t *testing.T) {
 	assert.True(t, mean(results) < emulator.T.MeanTemperature)
 }
 
-func TestTemperatureEmulationAnomalies_Decrease_Trend_Time_Duration_Test_B(t *testing.T) {
-	emulator := createEmulator(14400, 0)
-	emulator.T.IsTrendAnomaly = true
-	emulator.T.TrendAnomalyMagnitude = 30.0
-	emulator.T.TrendAnomalyLength = 1e3
-	emulator.T.IsRisingTrendAnomaly = false
+// func TestTemperatureEmulationAnomalies_Decrease_Trend_Time_Duration_Test_B(t *testing.T) {
+// 	emulator := createEmulator(14400, 0)
+// 	emulator.T.IsTrendAnomaly = true
+// 	emulator.T.TrendAnomalyMagnitude = 30.0
+// 	emulator.T.TrendAnomalyLength = 1e3
+// 	emulator.T.IsRisingTrendAnomaly = false
 
-	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
-	emulator.T.TrendAnomalyTimeDuration = 20
+// 	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
+// 	emulator.T.TrendAnomalyTimeDuration = 20
 
-	var results []float64
-	results = emulator.Time_base_duration_loop(emulator.T.TrendAnomalyTimeStart, emulator.T.TrendAnomalyTimeDuration)
+// 	var results []float64
+// 	results = emulator.Time_base_duration_loop(emulator.T.TrendAnomalyTimeStart, emulator.T.TrendAnomalyTimeDuration)
 
-	assert.True(t, mean(results) < emulator.T.MeanTemperature)
-}
+// 	assert.True(t, mean(results) < emulator.T.MeanTemperature)
+// }
 
-func TestTemperatureEmulationAnomalies_Decrease_Trend_Time_Duration(t *testing.T) {
-	emulator := createEmulator(14400, 0)
-	emulator.T.IsTrendAnomaly = true
-	emulator.T.TrendAnomalyMagnitude = 30.0
-	emulator.T.TrendAnomalyLength = 1e3
-	emulator.T.IsRisingTrendAnomaly = false
+// func TestTemperatureEmulationAnomalies_Decrease_Trend_Time_Duration(t *testing.T) {
+// 	emulator := createEmulator(14400, 0)
+// 	emulator.T.IsTrendAnomaly = true
+// 	emulator.T.TrendAnomalyMagnitude = 30.0
+// 	emulator.T.TrendAnomalyLength = 1e3
+// 	emulator.T.IsRisingTrendAnomaly = false
 
-	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
-	emulator.T.TrendAnomalyTimeDuration = 20
+// 	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
+// 	emulator.T.TrendAnomalyTimeDuration = 20
 
-	var results []float64
-	for continue_flag := true; continue_flag; continue_flag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
-		emulator.Step()
-		results = append(results, emulator.T.T)
-		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
-	}
+// 	var results []float64
+// 	for continue_flag := true; continue_flag; continue_flag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
+// 		emulator.Step()
+// 		results = append(results, emulator.T.T)
+// 		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
+// 	}
 
-	assert.True(t, mean(results) < emulator.T.MeanTemperature)
-}
+// 	assert.True(t, mean(results) < emulator.T.MeanTemperature)
+// }
 
 func TestSagEmulation(t *testing.T) {
 	emulator := createEmulator(14400, 0)

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -3,6 +3,7 @@ package emulator
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -137,6 +138,26 @@ func TestTemperatureEmulationAnomalies_Trend(t *testing.T) {
 	assert.True(t, mean(results) > emulator.T.MeanTemperature)
 }
 
+func TestTemperatureEmulationAnomalies_Trend_Time_Duration(t *testing.T) {
+	emulator := createEmulator(14400, 0)
+	emulator.T.IsTrendAnomaly = true
+	emulator.T.TrendAnomalyMagnitude = 30.0
+	emulator.T.TrendAnomalyLength = 1e3
+	emulator.T.IsRisingTrendAnomaly = true
+
+	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
+	emulator.T.TrendAnomalyTimeDuration = 20
+
+	var results []float64
+	for continue_flag := true; continue_flag; continue_flag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
+		emulator.Step()
+		results = append(results, emulator.T.T)
+		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
+	}
+
+	assert.True(t, mean(results) > emulator.T.MeanTemperature)
+}
+
 func TestTemperatureEmulationAnomalies_Decrease_Trend(t *testing.T) {
 	emulator := createEmulator(14400, 0)
 	emulator.T.IsTrendAnomaly = true
@@ -149,6 +170,26 @@ func TestTemperatureEmulationAnomalies_Decrease_Trend(t *testing.T) {
 		emulator.Step()
 		results = append(results, emulator.T.T)
 		step += 1
+	}
+
+	assert.True(t, mean(results) < emulator.T.MeanTemperature)
+}
+
+func TestTemperatureEmulationAnomalies_Decrease_Trend_Time_Duration(t *testing.T) {
+	emulator := createEmulator(14400, 0)
+	emulator.T.IsTrendAnomaly = true
+	emulator.T.TrendAnomalyMagnitude = 30.0
+	emulator.T.TrendAnomalyLength = 1e3
+	emulator.T.IsRisingTrendAnomaly = false
+
+	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
+	emulator.T.TrendAnomalyTimeDuration = 20
+
+	var results []float64
+	for continue_flag := true; continue_flag; continue_flag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
+		emulator.Step()
+		results = append(results, emulator.T.T)
+		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
 	}
 
 	assert.True(t, mean(results) < emulator.T.MeanTemperature)

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -1,7 +1,6 @@
 package emulator
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -60,8 +59,6 @@ func createEmulator(samplingRate int, phaseOffsetDeg float64) *Emulator {
 		NoiseMax:                        0.01,
 		InstantaneousAnomalyMagnitude:   30,
 		InstantaneousAnomalyProbability: 0.01,
-		// TrendAnomalyTimeStart:           time.Now().Unix(),
-		// TrendAnomalyTimeDuration:        20,
 	}
 	return emu
 }
@@ -123,8 +120,8 @@ func TestTemperatureEmulationAnomalies_Anomalies(t *testing.T) {
 	assert.True(t, mean(anomalyValues) > mean(normalValues))
 }
 
-func TestTemperatureEmulationAnomalies_Trend(t *testing.T) {
-	emulator := createEmulator(100, 0)
+func TestTemperatureEmulationAnomalies_RisingTrend(t *testing.T) {
+	emulator := createEmulator(14400, 0)
 	emulator.T.IsTrendAnomaly = true
 	emulator.T.TrendAnomalyMagnitude = 30.0
 	emulator.T.TrendAnomalyDuration = 10
@@ -132,55 +129,20 @@ func TestTemperatureEmulationAnomalies_Trend(t *testing.T) {
 
 	step := 0
 	var results []float64
-	//duration times frequency equals total steps?
 	for step < emulator.T.TrendAnomalyDuration*emulator.SamplingRate {
 		emulator.Step()
 		results = append(results, emulator.T.T)
 		step += 1
+
+		if step < emulator.SamplingRate {
+			assert.NotEqual(t, 0, emulator.T.TrendAnomalyIndex)
+		}
 	}
-	fmt.Println(step)
 
 	assert.True(t, mean(results) > emulator.T.MeanTemperature)
 }
 
-// func TestTemperatureEmulationAnomalies_Trend_Time_Duration(t *testing.T) {
-// 	emulator := createEmulator(14400, 0)
-// 	emulator.T.IsTrendAnomaly = true
-// 	emulator.T.TrendAnomalyMagnitude = 30.0
-// 	emulator.T.TrendAnomalyLength = 1e3
-// 	emulator.T.IsRisingTrendAnomaly = true
-
-// 	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
-// 	emulator.T.TrendAnomalyTimeDuration = 20
-
-// 	var results []float64
-// 	for continueFlag := true; continueFlag; continueFlag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
-// 		emulator.Step()
-// 		results = append(results, emulator.T.T)
-// 		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
-// 	}
-
-// 	assert.True(t, mean(results) > emulator.T.MeanTemperature)
-// }
-
-//TODO unit test for the new time duration loop
-// func TestTemperatureEmulationAnomalies_Trend_Time_Duration_Test_B(t *testing.T) {
-// 	emulator := createEmulator(14400, 0)
-// 	emulator.T.IsTrendAnomaly = true
-// 	emulator.T.TrendAnomalyMagnitude = 30.0
-// 	emulator.T.TrendAnomalyLength = 1e3
-// 	emulator.T.IsRisingTrendAnomaly = true
-
-// 	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
-// 	emulator.T.TrendAnomalyTimeDuration = 20
-
-// 	var results []float64
-// 	results = emulator.Time_base_duration_loop(emulator.T.TrendAnomalyTimeStart, emulator.T.TrendAnomalyTimeDuration)
-
-// 	assert.True(t, mean(results) > emulator.T.MeanTemperature)
-// }
-
-func TestTemperatureEmulationAnomalies_Decrease_Trend(t *testing.T) {
+func TestTemperatureEmulationAnomalies_DecreasingTrend(t *testing.T) {
 	emulator := createEmulator(1, 0)
 	emulator.T.IsTrendAnomaly = true
 	emulator.T.TrendAnomalyMagnitude = 30.0
@@ -196,42 +158,6 @@ func TestTemperatureEmulationAnomalies_Decrease_Trend(t *testing.T) {
 
 	assert.True(t, mean(results) < emulator.T.MeanTemperature)
 }
-
-// func TestTemperatureEmulationAnomalies_Decrease_Trend_Time_Duration_Test_B(t *testing.T) {
-// 	emulator := createEmulator(14400, 0)
-// 	emulator.T.IsTrendAnomaly = true
-// 	emulator.T.TrendAnomalyMagnitude = 30.0
-// 	emulator.T.TrendAnomalyLength = 1e3
-// 	emulator.T.IsRisingTrendAnomaly = false
-
-// 	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
-// 	emulator.T.TrendAnomalyTimeDuration = 20
-
-// 	var results []float64
-// 	results = emulator.Time_base_duration_loop(emulator.T.TrendAnomalyTimeStart, emulator.T.TrendAnomalyTimeDuration)
-
-// 	assert.True(t, mean(results) < emulator.T.MeanTemperature)
-// }
-
-// func TestTemperatureEmulationAnomalies_Decrease_Trend_Time_Duration(t *testing.T) {
-// 	emulator := createEmulator(14400, 0)
-// 	emulator.T.IsTrendAnomaly = true
-// 	emulator.T.TrendAnomalyMagnitude = 30.0
-// 	emulator.T.TrendAnomalyLength = 1e3
-// 	emulator.T.IsRisingTrendAnomaly = false
-
-// 	emulator.T.TrendAnomalyTimeStart = time.Now().Unix()
-// 	emulator.T.TrendAnomalyTimeDuration = 20
-
-// 	var results []float64
-// 	for continue_flag := true; continue_flag; continue_flag = (emulator.T.TrendAnomalyTimeCurrent - emulator.T.TrendAnomalyTimeStart) < emulator.T.TrendAnomalyTimeDuration {
-// 		emulator.Step()
-// 		results = append(results, emulator.T.T)
-// 		emulator.T.TrendAnomalyTimeCurrent = time.Now().Unix()
-// 	}
-
-// 	assert.True(t, mean(results) < emulator.T.MeanTemperature)
-// }
 
 func TestSagEmulation(t *testing.T) {
 	emulator := createEmulator(14400, 0)


### PR DESCRIPTION
Adding a few TrendAnomalyTime attributes in TemperatureEmulation struct to implement time duration feature for looping.  In unit tests, I set 20 seconds for the total time duration.