### PR TITLE
Add yaml tags and comments to fields

### DIFF
--- a/anomaly.go
+++ b/anomaly.go
@@ -9,13 +9,13 @@ type Anomaly struct {
 	InstantaneousAnomalyMagnitude   float64
 
 	// trend anomalies, providing periodic positive or negative slopes of given magnitude and duration
-	IsTrendAnomaly        bool
-	IsRisingTrendAnomaly  bool
-	TrendAnomalyDuration  float64 // duration in seconds
-	TrendStartDelay       float64 // duration in seconds
-	TrendStartIndex       int     // number of time step ticks
-	TrendAnomalyIndex     int     // number of time step ticks
-	TrendAnomalyMagnitude float64
+	IsTrendAnomaly        bool    `yaml:"IsTrendAnomaly"`
+	IsRisingTrendAnomaly  bool    `yaml:"IsRisingTrendAnomaly"`
+	TrendAnomalyDuration  float64 `yaml:"TrendAnomalyDuration"` // duration in seconds
+	TrendStartDelay       float64 `yaml:"TrendStartDelay"`      // duration in seconds
+	TrendStartIndex       int     `yaml:"TrendStartIndex"`      // number of time step ticks
+	TrendAnomalyIndex     int     `yaml:"TrendAnomalyIndex"`    // number of time step ticks
+	TrendAnomalyMagnitude float64 `yaml:"TrendAnomalyMagnitude"`
 }
 
 func (anomaly *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {

--- a/emulator.go
+++ b/emulator.go
@@ -39,11 +39,11 @@ type Emulator struct {
 	Fnom         float64 `yaml:"Fnom"`         // Nominal frequency
 	Fdeviation   float64 `yaml:"Fdeviation"`   // Frequency deviation
 
-	V *ThreePhaseEmulation `yaml:"VoltageEmulator"` // Voltage Emulator
-	I *ThreePhaseEmulation `yaml:"CurrentEmulator"` // Current Emulator
+	V *ThreePhaseEmulation `yaml:"VoltageEmulator,omitempty"` // Voltage Emulator
+	I *ThreePhaseEmulation `yaml:"CurrentEmulator,omitempty"` // Current Emulator
 
-	T   *TemperatureEmulation `yaml:"TemperatureEmulator"` // Temperature Emulation
-	Sag *SagEmulation         `yaml:"SagEmulator"`         // Sag Emulator
+	T   *TemperatureEmulation `yaml:"TemperatureEmulator,omitempty"` // Temperature Emulation
+	Sag *SagEmulation         `yaml:"SagEmulator,omitempty"`         // Sag Emulator
 
 	// common state
 	SmpCnt                     int `yaml:"-"`

--- a/emulator.go
+++ b/emulator.go
@@ -34,22 +34,22 @@ const EmulatedFaultCurrentMagnitude = 80
 // Emulator encapsulates the waveform emulation of three-phase voltage, three-phase current, or temperature
 type Emulator struct {
 	// common inputs
-	SamplingRate int
-	Ts           float64
-	Fnom         float64
-	Fdeviation   float64
+	SamplingRate int     `yaml:"SamplingRate"` // The sampling rate of the emulator
+	Ts           float64 `yaml:"Ts"`           // The time step for a given sampling rate
+	Fnom         float64 `yaml:"Fnom"`         // Nominal frequency
+	Fdeviation   float64 `yaml:"Fdeviation"`   // Frequency deviation
 
-	V *ThreePhaseEmulation
-	I *ThreePhaseEmulation
+	V *ThreePhaseEmulation `yaml:"VoltageEmulator"` // Voltage Emulator
+	I *ThreePhaseEmulation `yaml:"CurrentEmulator"` // Current Emulator
 
-	T   *TemperatureEmulation
-	Sag *SagEmulation
+	T   *TemperatureEmulation `yaml:"TemperatureEmulator"` // Temperature Emulation
+	Sag *SagEmulation         `yaml:"SagEmulator"`         // Sag Emulator
 
 	// common state
-	SmpCnt                     int
-	fDeviationRemainingSamples int
+	SmpCnt                     int `yaml:"-"`
+	fDeviationRemainingSamples int `yaml:"-"`
 
-	r *rand.Rand
+	r *rand.Rand `yaml:"-"`
 }
 
 // StartEvent initiates an emulated event
@@ -61,12 +61,12 @@ func (e *Emulator) StartEvent(eventType int) {
 		// TODO
 		// e.I.FaultPosSeqMag = EmulatedFaultCurrentMagnitude
 		// e.I.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
-		e.I.FaultPhaseAMag = e.I.PosSeqMag * 1.2 //EmulatedFaultCurrentMagnitude
+		e.I.FaultPhaseAMag = e.I.PosSeqMag * 1.2 // EmulatedFaultCurrentMagnitude
 		e.I.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
 		e.V.FaultPhaseAMag = e.V.PosSeqMag * -0.2
 		e.V.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
 	case ThreePhaseFault:
-		e.I.FaultPosSeqMag = e.I.PosSeqMag * 1.2 //EmulatedFaultCurrentMagnitude
+		e.I.FaultPosSeqMag = e.I.PosSeqMag * 1.2 // EmulatedFaultCurrentMagnitude
 		e.I.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
 		e.V.FaultPosSeqMag = e.V.PosSeqMag * -0.2
 		e.V.FaultRemainingSamples = MaxEmulatedFaultDurationSamples

--- a/sag.go
+++ b/sag.go
@@ -6,9 +6,9 @@ import (
 )
 
 type SagEmulation struct {
-	MeanStrain                float64 `yaml:"MeanStrain"`                // Mean strain
-	MeanSag                   float64 `yaml:"MeanSag"`                   // Mean sag
-	MeanCalculatedTemperature float64 `yaml:"MeanCalculatedTemperature"` // Mean calculated temperature
+	MeanStrain                float64 `yaml:"MeanStrain,omitempty"`                // Mean strain
+	MeanSag                   float64 `yaml:"MeanSag,omitempty"`                   // Mean sag
+	MeanCalculatedTemperature float64 `yaml:"MeanCalculatedTemperature,omitempty"` // Mean calculated temperature
 
 	// outputs
 	TotalStrain           float64 `yaml:"-"` // Total strain

--- a/sag.go
+++ b/sag.go
@@ -6,14 +6,14 @@ import (
 )
 
 type SagEmulation struct {
-	MeanStrain                float64
-	MeanSag                   float64
-	MeanCalculatedTemperature float64
+	MeanStrain                float64 `yaml:"MeanStrain"`                // Mean strain
+	MeanSag                   float64 `yaml:"MeanSag"`                   // Mean sag
+	MeanCalculatedTemperature float64 `yaml:"MeanCalculatedTemperature"` // Mean calculated temperature
 
 	// outputs
-	TotalStrain           float64
-	Sag                   float64
-	CalculatedTemperature float64
+	TotalStrain           float64 `yaml:"-"` // Total strain
+	Sag                   float64 `yaml:"-"` // Sag
+	CalculatedTemperature float64 `yaml:"-"` // Calculated temperature
 }
 
 func (e *SagEmulation) stepSag(r *rand.Rand) {

--- a/temperature.go
+++ b/temperature.go
@@ -6,13 +6,13 @@ import (
 )
 
 type TemperatureEmulation struct {
-	MeanTemperature float64
-	NoiseMax        float64
-	ModulationMag   float64
+	MeanTemperature float64 `yaml:"MeanTemperature"` // Mean temperature
+	NoiseMax        float64 `yaml:"NoseMax"`         // Maximum noise
+	ModulationMag   float64 `yaml:"ModulationMag"`   // Magnitude modulation
 
-	Anomaly Anomaly
+	Anomaly Anomaly `yaml:"Anomaly"` // Anomaly
 
-	T float64
+	T float64 `yaml:"-"`
 }
 
 func (t *TemperatureEmulation) stepTemperature(r *rand.Rand, Ts float64) {

--- a/temperature.go
+++ b/temperature.go
@@ -6,9 +6,9 @@ import (
 )
 
 type TemperatureEmulation struct {
-	MeanTemperature float64 `yaml:"MeanTemperature"` // Mean temperature
-	NoiseMax        float64 `yaml:"NoseMax"`         // Maximum noise
-	ModulationMag   float64 `yaml:"ModulationMag"`   // Magnitude modulation
+	MeanTemperature float64 `yaml:"MeanTemperature"`         // Mean temperature
+	NoiseMax        float64 `yaml:"NoseMax"`                 // Maximum noise
+	ModulationMag   float64 `yaml:"ModulationMag,omitempty"` // Magnitude modulation
 
 	Anomaly Anomaly `yaml:"Anomaly"` // Anomaly
 

--- a/threephase.go
+++ b/threephase.go
@@ -11,16 +11,16 @@ const TwoPiOverThree = 2 * math.Pi / 3
 
 type ThreePhaseEmulation struct {
 	// inputs
-	PosSeqMag       float64   `yaml:"PosSeqMag"`            // Positive Sequence Magnitude
-	PhaseOffset     float64   `yaml:"PhaseOffset"`          // Phase Offset
-	NegSeqMag       float64   `yaml:"NegSeqMag"`            // Negative Sequence Magnitude
-	NegSeqAng       float64   `yaml:"NegSeqAng"`            // Negative Sequence Angle
-	ZeroSeqMag      float64   `yaml:"ZeroSeqMag"`           // Zero Sequence Magnitude
-	ZeroSeqAng      float64   `yaml:"ZeroSeqAng"`           // Zero Sequence Angle
-	HarmonicNumbers []float64 `yaml:"HarmonicNumbers,flow"` // Harmonic Numbers
-	HarmonicMags    []float64 `yaml:"HarmonicMags,flow"`    // Harmonic magnitudes in pu, relative to PosSeqMag
-	HarmonicAngs    []float64 `yaml:"HarmonicAngs,flow"`    // Harmonic Angles
-	NoiseMax        float64   `yaml:"NoiseMax"`             // Maximum noise
+	PosSeqMag       float64   `yaml:"PosSeqMag"`                      // Positive Sequence Magnitude
+	PhaseOffset     float64   `yaml:"PhaseOffset,omitempty"`          // Phase Offset
+	NegSeqMag       float64   `yaml:"NegSeqMag,omitempty"`            // Negative Sequence Magnitude
+	NegSeqAng       float64   `yaml:"NegSeqAng,omitempty"`            // Negative Sequence Angle
+	ZeroSeqMag      float64   `yaml:"ZeroSeqMag,omitempty"`           // Zero Sequence Magnitude
+	ZeroSeqAng      float64   `yaml:"ZeroSeqAng,omitempty"`           // Zero Sequence Angle
+	HarmonicNumbers []float64 `yaml:"HarmonicNumbers,flow,omitempty"` // Harmonic Numbers
+	HarmonicMags    []float64 `yaml:"HarmonicMags,flow,omitempty"`    // Harmonic magnitudes in pu, relative to PosSeqMag
+	HarmonicAngs    []float64 `yaml:"HarmonicAngs,flow,omitempty"`    // Harmonic Angles
+	NoiseMax        float64   `yaml:"NoiseMax,omitempty"`             // Maximum noise
 
 	// define anomalies
 	PosSeqMagAnomaly Anomaly // positive sequence magnitude anomaly

--- a/threephase.go
+++ b/threephase.go
@@ -11,16 +11,16 @@ const TwoPiOverThree = 2 * math.Pi / 3
 
 type ThreePhaseEmulation struct {
 	// inputs
-	PosSeqMag       float64   `yaml:"PosSeqMag"`       // Positive Sequence Magnitude
-	PhaseOffset     float64   `yaml:"PhaseOffset"`     // Phase Offset
-	NegSeqMag       float64   `yaml:"NegSeqMag"`       // Negative Sequence Magnitude
-	NegSeqAng       float64   `yaml:"NegSeqAng"`       // Negative Sequence Angle
-	ZeroSeqMag      float64   `yaml:"ZeroSeqMag"`      // Zero Sequence Magnitude
-	ZeroSeqAng      float64   `yaml:"ZeroSeqAng"`      // Zero Sequence Angle
-	HarmonicNumbers []float64 `yaml:"HarmonicNumbers"` // Harmonic Numbers
-	HarmonicMags    []float64 `yaml:"HarmonicMags"`    // Harmonic magnitudes in pu, relative to PosSeqMag
-	HarmonicAngs    []float64 `yaml:"HarmonicAngs"`    // Harmonic Angles
-	NoiseMax        float64   `yaml:"NoiseMax"`        // Maximum noise
+	PosSeqMag       float64   `yaml:"PosSeqMag"`            // Positive Sequence Magnitude
+	PhaseOffset     float64   `yaml:"PhaseOffset"`          // Phase Offset
+	NegSeqMag       float64   `yaml:"NegSeqMag"`            // Negative Sequence Magnitude
+	NegSeqAng       float64   `yaml:"NegSeqAng"`            // Negative Sequence Angle
+	ZeroSeqMag      float64   `yaml:"ZeroSeqMag"`           // Zero Sequence Magnitude
+	ZeroSeqAng      float64   `yaml:"ZeroSeqAng"`           // Zero Sequence Angle
+	HarmonicNumbers []float64 `yaml:"HarmonicNumbers,flow"` // Harmonic Numbers
+	HarmonicMags    []float64 `yaml:"HarmonicMags,flow"`    // Harmonic magnitudes in pu, relative to PosSeqMag
+	HarmonicAngs    []float64 `yaml:"HarmonicAngs,flow"`    // Harmonic Angles
+	NoiseMax        float64   `yaml:"NoiseMax"`             // Maximum noise
 
 	// define anomalies
 	PosSeqMagAnomaly Anomaly // positive sequence magnitude anomaly

--- a/threephase.go
+++ b/threephase.go
@@ -11,16 +11,16 @@ const TwoPiOverThree = 2 * math.Pi / 3
 
 type ThreePhaseEmulation struct {
 	// inputs
-	PosSeqMag       float64
-	PhaseOffset     float64
-	NegSeqMag       float64
-	NegSeqAng       float64
-	ZeroSeqMag      float64
-	ZeroSeqAng      float64
-	HarmonicNumbers []float64
-	HarmonicMags    []float64 // pu, relative to PosSeqMag
-	HarmonicAngs    []float64
-	NoiseMax        float64
+	PosSeqMag       float64   `yaml:"PosSeqMag"`       // Positive Sequence Magnitude
+	PhaseOffset     float64   `yaml:"PhaseOffset"`     // Phase Offset
+	NegSeqMag       float64   `yaml:"NegSeqMag"`       // Negative Sequence Magnitude
+	NegSeqAng       float64   `yaml:"NegSeqAng"`       // Negative Sequence Angle
+	ZeroSeqMag      float64   `yaml:"ZeroSeqMag"`      // Zero Sequence Magnitude
+	ZeroSeqAng      float64   `yaml:"ZeroSeqAng"`      // Zero Sequence Angle
+	HarmonicNumbers []float64 `yaml:"HarmonicNumbers"` // Harmonic Numbers
+	HarmonicMags    []float64 `yaml:"HarmonicMags"`    // Harmonic magnitudes in pu, relative to PosSeqMag
+	HarmonicAngs    []float64 `yaml:"HarmonicAngs"`    // Harmonic Angles
+	NoiseMax        float64   `yaml:"NoiseMax"`        // Maximum noise
 
 	// define anomalies
 	PosSeqMagAnomaly Anomaly // positive sequence magnitude anomaly
@@ -30,19 +30,19 @@ type ThreePhaseEmulation struct {
 	HarmonicsAnomaly Anomaly // harmonics magnitude anomaly
 
 	// event emulation
-	FaultPhaseAMag        float64
-	FaultPosSeqMag        float64
-	FaultRemainingSamples int
+	FaultPhaseAMag        float64 `yaml:"-"`
+	FaultPosSeqMag        float64 `yaml:"-"`
+	FaultRemainingSamples int     `yaml:"-"`
 
 	// state change
-	PosSeqMagNew      float64
-	PosSeqMagRampRate float64
+	PosSeqMagNew      float64 `yaml:"-"`
+	PosSeqMagRampRate float64 `yaml:"-"`
 
 	// internal state
-	pAngle float64
+	pAngle float64 `yaml:"-"`
 
 	// outputs
-	A, B, C float64
+	A, B, C float64 `yaml:"-"`
 }
 
 func (e *ThreePhaseEmulation) stepThreePhase(r *rand.Rand, f float64, Ts float64, smpCnt int) {


### PR DESCRIPTION
While writing some config file generation scripts with emulators to pass the time on my flight to London, I came across some struggles with marshalling the emulator `Variables` header with the emulators, because none of the fields had yaml tags. 

This PR aims to enable this automated emulator config writing logic by only marshalling configurable emulator fields, and changes no core functionality.