### PR TITLE
Update to use `math/rand/v2`

### DIFF
--- a/anomaly.go
+++ b/anomaly.go
@@ -1,6 +1,6 @@
 package emulator
 
-import "math/rand"
+import "math/rand/v2"
 
 type Anomaly struct {
 	// instantaneous anomalies, based on probability factor

--- a/emulator.go
+++ b/emulator.go
@@ -1,8 +1,6 @@
 package emulator
 
-import (
-	"math/rand/v2"
-)
+import "math/rand/v2"
 
 // Emulated event types
 const (

--- a/emulator.go
+++ b/emulator.go
@@ -1,8 +1,7 @@
 package emulator
 
 import (
-	"hash/maphash"
-	"math/rand"
+	"math/rand/v2"
 )
 
 // Emulated event types
@@ -98,7 +97,7 @@ func NewEmulator(samplingRate int, frequency float64) *Emulator {
 		Ts:           1 / float64(samplingRate),
 	}
 
-	emu.r = rand.New(rand.NewSource(int64(new(maphash.Hash).Sum64())))
+	emu.r = rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 
 	return emu
 }

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -65,7 +65,7 @@ func createEmulator(samplingRate int, phaseOffsetDeg float64) *Emulator {
 	return emu
 }
 
-func createEmulatorForAnomaly(samplingRate int, phaseOffsetDeg float64) *Emulator {
+func createEmulatorForAnomaly(samplingRate int) *Emulator {
 	emu := NewEmulator(samplingRate, 50.0)
 
 	emu.I = &ThreePhaseEmulation{
@@ -84,10 +84,7 @@ func createEmulatorForAnomaly(samplingRate int, phaseOffsetDeg float64) *Emulato
 
 func FloatingPointEqual(expected float64, actual float64, threshold float64) bool {
 	absDiff := math.Abs(expected - actual)
-	if absDiff < threshold {
-		return true
-	}
-	return false
+	return absDiff < threshold
 }
 
 func mean(values []float64) float64 {
@@ -179,7 +176,7 @@ func TestTemperatureEmulationAnomalies_DecreasingTrend(t *testing.T) {
 }
 
 func TestCurrentPosSeqAnomalies_RisingTrend(t *testing.T) {
-	emulator := createEmulatorForAnomaly(4000, 0)
+	emulator := createEmulatorForAnomaly(4000)
 
 	step := 0.0
 	var results []float64

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,14 @@
 module github.com/synaptecltd/emulator
 
-go 1.18
+go 1.22
 
-require github.com/stretchr/testify v1.8.1
+require (
+	github.com/stretchr/testify v1.8.1
+	github.com/teknico/sigourney v0.0.0-20160105013017-b52044632571
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/teknico/sigourney v0.0.0-20160105013017-b52044632571
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/sag.go
+++ b/sag.go
@@ -1,8 +1,7 @@
 package emulator
 
 import (
-	"math/rand"
-	"time"
+	"math/rand/v2"
 )
 
 type SagEmulation struct {
@@ -17,7 +16,6 @@ type SagEmulation struct {
 }
 
 func (e *SagEmulation) stepSag(r *rand.Rand) {
-	r.Seed(time.Now().UnixNano())
 	e.TotalStrain = e.MeanStrain * r.Float64()
 	e.Sag = e.MeanSag * r.Float64()
 	e.CalculatedTemperature = e.MeanCalculatedTemperature * r.Float64()

--- a/temperature.go
+++ b/temperature.go
@@ -2,7 +2,7 @@ package emulator
 
 import (
 	"math"
-	"math/rand"
+	"math/rand/v2"
 )
 
 type TemperatureEmulation struct {

--- a/threephase.go
+++ b/threephase.go
@@ -2,7 +2,7 @@ package emulator
 
 import (
 	"math"
-	"math/rand"
+	"math/rand/v2"
 
 	"github.com/teknico/sigourney/fast"
 )


### PR DESCRIPTION
# Changes

Updates the emulator to use [`math/rand/v2`](https://golang.google.cn/blog/randv2) for the simpler use and improved performance. 

This was introduced in go1.22 so the go.mod file has been updated to reflect this.

There aren't many changes required, but the `Seed()` function has been deleted in v2 as it's no longer needed. 

The `New()` definition also needed updated to specifically use the [PCG ](https://www.pcg-random.org/) generators.

## Benchmarks
### Old
```
goos: linux
goarch: amd64
pkg: github.com/synaptecltd/emulator
cpu: AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx
=== RUN   BenchmarkEmulator
BenchmarkEmulator
BenchmarkEmulator-8         1237            977723 ns/op               5 B/op          0 allocs/op
```

### New
```
goos: linux
goarch: amd64
pkg: github.com/synaptecltd/emulator
cpu: AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx
=== RUN   BenchmarkEmulator
BenchmarkEmulator
BenchmarkEmulator-8         1264            904054 ns/op               1 B/op          0 allocs/op
```