### PR TITLE
Extend emulator anomalies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,27 @@ emu.I = &emulator.ThreePhaseEmulation{
 emu.T = &emulator.TemperatureEmulation{
     MeanTemperature: 30.0,
     NoiseMax:        0.01,
-    Anomaly: emulator.Anomaly{
-        InstantaneousAnomalyMagnitude:   30,
-        InstantaneousAnomalyProbability: 0.01,
+    Anomaly: map[string]*emulator.Anomaly{
+        "ramp_and_spikes": {
+            InstantaneousAnomalyMagnitude:   30,
+            InstantaneousAnomalyProbability: 0.01,
+
+            IsTrendAnomaly:        true,
+            IsRisingTrendAnomaly:  true,
+            TrendAnomalyDuration:  0.2,
+            TrendStartDelay:       0.1,
+            TrendFuncName:         "linear",
+            TrendAnomalyMagnitude: 10,
+        },
+        "seasonality": {
+            IsTrendAnomaly:        true,
+            IsRisingTrendAnomaly:  true,
+            TrendAnomalyDuration:  1.0,
+            TrendStartDelay:       0,
+            TrendFuncName:         "sine",
+            TrendAnomalyMagnitude: 5,
+        },
+        // add more concurrent anomalies here
     },
 }
 
@@ -60,7 +78,7 @@ for step < samplingRate {
 
 Two types of "anomaly" can be added to the data to create interesting scenarios:
 1. Instantaneous: based on a probability factor, activate an instantaneous change to the selected parameter
-2. Periodic "trends": apply a sawtooth shape to the parameter
+2. Periodic "trends": apply a continuous changes to the parameter, including ramps, sinusoids, and additional noise. See `./mathfuncs` for a full list.
 
 The parameter `TrendAnomalyMagnitude` has the following effects:
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ emu.T = &emulator.TemperatureEmulation{
         "ramp_and_spikes": {
             InstantaneousAnomalyMagnitude:   30,
             InstantaneousAnomalyProbability: 0.01,
+            InstantaneousAnomalyMagnitudeVariation: true,
 
             IsTrendAnomaly:        true,
             IsRisingTrendAnomaly:  true,

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ emu.I = &emulator.ThreePhaseEmulation{
 emu.T = &emulator.TemperatureEmulation{
     MeanTemperature: 30.0,
     NoiseMax:        0.01,
-    Anomaly: map[string]*emulator.Anomaly{
+    Anomaly: emulator.AnomalyContainer{
         "ramp_and_spikes": {
             InstantaneousAnomalyMagnitude:   30,
             InstantaneousAnomalyProbability: 0.01,

--- a/README.md
+++ b/README.md
@@ -14,19 +14,20 @@ Each `emulator` instance can implement up to one of each of: three-phase voltage
 // base parameters
 samplingRate := 14400
 freq := 50.0
+phaseOffsetDeg := 0.0
 
 // create an emulator instance
-emu := NewEmulator(samplingRate, freq)
+emu := emulator.NewEmulator(samplingRate, freq)
 
 // specify three-phase voltage parameters
-emu.V = &ThreePhaseEmulation{
+emu.V = &emulator.ThreePhaseEmulation{
     PosSeqMag:   400000.0 / math.Sqrt(3) * math.Sqrt(2),
     NoiseMax:    0.000001,
     PhaseOffset: phaseOffsetDeg * math.Pi / 180.0,
 }
 
 // specify three-phase current parameters
-emu.I = &ThreePhaseEmulation{
+emu.I = &emulator.ThreePhaseEmulation{
     PosSeqMag:       500.0,
     PhaseOffset:     phaseOffsetDeg * math.Pi / 180.0,
     HarmonicNumbers: []float64{5, 7, 11, 13, 17, 19, 23, 25},
@@ -36,10 +37,10 @@ emu.I = &ThreePhaseEmulation{
 }
 
 // specify temperature parameters
-emu.T = &TemperatureEmulation{
+emu.T = &emulator.TemperatureEmulation{
     MeanTemperature: 30.0,
     NoiseMax:        0.01,
-    Anomaly: Anomaly{
+    Anomaly: emulator.Anomaly{
         InstantaneousAnomalyMagnitude:   30,
         InstantaneousAnomalyProbability: 0.01,
     },
@@ -47,10 +48,10 @@ emu.T = &TemperatureEmulation{
 
 // execute one full waveform period of samples using the Step() function
 step := 0
-var results []bool
+var results []float64
 for step < samplingRate {
-    emulator.Step()
-    results = append(results, emulator.T.Anomaly.isInstantaneousAnomaly)
+    emu.Step()
+    results = append(results, emu.T.T)
     step += 1
 }
 ```

--- a/anomaly.go
+++ b/anomaly.go
@@ -11,9 +11,10 @@ import (
 //   - TrendAnomaly provides periodic positive or negative slopes of given magnitude and duration
 type Anomaly struct {
 	// Instantaneous anomalies
-	InstantaneousAnomalyProbability float64 `yaml:"InstantaneousAnomalyProbability"` // probability of instantaneous anomaly in each time step
-	InstantaneousAnomalyMagnitude   float64 `yaml:"InstantaneousAnomalyMagnitude"`   // magnitude of instantaneous anomalies
-	InstantaneousAnomalyActive      bool    // indicates whether instantaneous anomaly is active in this time step
+	InstantaneousAnomalyProbability        float64 `yaml:"InstantaneousAnomalyProbability"`        // probability of instantaneous anomaly in each time step
+	InstantaneousAnomalyMagnitude          float64 `yaml:"InstantaneousAnomalyMagnitude"`          // magnitude of instantaneous anomalies
+	InstantaneousAnomalyMagnitudeVariation bool    `yaml:"InstantaneousAnomalyMagnitudeVariation"` // whether to vary the magnitude of the instantaneous anomaly, default false
+	InstantaneousAnomalyActive             bool    // indicates whether instantaneous anomaly is active in this time step
 
 	// Trend anomalies
 	IsTrendAnomaly        bool    `yaml:"IsTrendAnomaly"`        // true: trend anomalies activated, false: deactivated
@@ -57,7 +58,11 @@ func (a *Anomaly) getInstantaneousDelta(r *rand.Rand) float64 {
 	instantaneousAnomalyDelta := 0.0
 	a.InstantaneousAnomalyActive = false
 	if a.InstantaneousAnomalyProbability > r.Float64() {
-		instantaneousAnomalyDelta = a.InstantaneousAnomalyMagnitude
+		if a.InstantaneousAnomalyMagnitudeVariation {
+			instantaneousAnomalyDelta = a.InstantaneousAnomalyMagnitude * r.NormFloat64()
+		} else {
+			instantaneousAnomalyDelta = a.InstantaneousAnomalyMagnitude
+		}
 		a.InstantaneousAnomalyActive = true
 	}
 	return instantaneousAnomalyDelta

--- a/anomaly.go
+++ b/anomaly.go
@@ -3,12 +3,42 @@ package emulator
 import "math/rand/v2"
 
 type Anomaly struct {
-	// instantaneous anomalies, based on probability factor
-	InstantaneousAnomalyProbability float64 `yaml:"InstantaneousAnomalyProbability"` // probability of an instantaneous anomaly in each time step
+	InstantaneousAnomaly
+	TrendAnomaly
+}
+
+// Calculates the anomaly delta for the current timestep based on all active anomalies. Ts is the sampling
+// period of the data in seconds, and r is a random number generator.
+func (anomaly *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {
+	instantaneousAnomalyDelta := anomaly.InstantaneousAnomaly.getDelta(r)
+	trendAnomalyDelta := anomaly.TrendAnomaly.getDelta(Ts)
+
+	totalAnomalyDelta := trendAnomalyDelta + instantaneousAnomalyDelta
+
+	return totalAnomalyDelta
+}
+
+// InstantaneousAnomaly provides a spike in the temperature based on a probability factor.
+type InstantaneousAnomaly struct {
+	InstantaneousAnomalyProbability float64 `yaml:"InstantaneousAnomalyProbability"` // probability of instantaneous anomaly in each time step
 	InstantaneousAnomalyMagnitude   float64 `yaml:"InstantaneousAnomalyMagnitude"`   // magnitude of instantaneous anomalies
 	InstantaneousAnomalyActive      bool    // whether an instantaneous anomaly is active in this time step
+}
 
-	// trend anomalies, providing periodic positive or negative slopes of given magnitude and duration
+// Returns the instantaneous anomaly delta. The anomaly is activated based
+// by comparing a random number with the probability of an anomaly occuring.
+func (a *InstantaneousAnomaly) getDelta(r *rand.Rand) float64 {
+	instantaneousAnomalyDelta := 0.0
+	a.InstantaneousAnomalyActive = false
+	if a.InstantaneousAnomalyProbability > r.Float64() {
+		instantaneousAnomalyDelta = a.InstantaneousAnomalyMagnitude
+		a.InstantaneousAnomalyActive = true
+	}
+	return instantaneousAnomalyDelta
+}
+
+// TrendAnomaly provides periodic positive or negative slopes of given magnitude and duration
+type TrendAnomaly struct {
 	IsTrendAnomaly        bool    `yaml:"IsTrendAnomaly"`        // true to turn trend anomalies on, false to deactivate
 	IsRisingTrendAnomaly  bool    `yaml:"IsRisingTrendAnomaly"`  // true for positive slope, false for negative slope
 	TrendAnomalyDuration  float64 `yaml:"TrendAnomalyDuration"`  // duration of trend anomaly in seconds
@@ -19,51 +49,68 @@ type Anomaly struct {
 	TrendRepetition       int     `yaml:"TrendRepetition"`       // number of times the trend anomaly is repeated, default 0 for infinite
 	TrendAnomalyActive    bool    // whether a trend anomaly is active in this time step
 
-	trendRepeats int // counter for number of times the trend anomaly has been repeated
+	trendRepeats int // internal counter for number of times the trend anomaly has been repeated
 }
 
-func (anomaly *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {
-	// Define trend anomalies
-	trendAnomalyDelta := 0.0
-	anomaly.TrendAnomalyActive = false
-	if anomaly.IsTrendAnomaly && anomaly.TrendAnomalyDuration > 0.0 && (anomaly.trendRepeats < anomaly.TrendRepetition || anomaly.TrendRepetition == 0) {
-		anomaly.TrendAnomalyActive = true
-		trendAnomalyStep := (anomaly.TrendAnomalyMagnitude / anomaly.TrendAnomalyDuration) * Ts
-
-		if anomaly.TrendStartIndex >= int(anomaly.TrendStartDelay/Ts)-1 {
-			if anomaly.IsRisingTrendAnomaly {
-				trendAnomalyDelta = float64(anomaly.TrendAnomalyIndex) * trendAnomalyStep
-			} else {
-				trendAnomalyDelta = float64(anomaly.TrendAnomalyIndex) * trendAnomalyStep * (-1.0)
-			}
-
-			if anomaly.TrendAnomalyIndex == int(anomaly.TrendAnomalyDuration/Ts)-1 {
-				anomaly.TrendAnomalyIndex = 0
-				anomaly.TrendStartIndex = 0
-				anomaly.trendRepeats += 1
-			} else {
-				anomaly.TrendAnomalyIndex += 1
-			}
-		} else {
-			anomaly.TrendStartIndex += 1
-		}
+// Returns the trend anomaly delta and increments the internal index of the anomaly to
+// track the progress of the anomaly. Ts is the sampling period of the data.
+// The duration and progress of the anomaly is tracked internally.
+func (t *TrendAnomaly) getDelta(Ts float64) float64 {
+	// Check if the trend anomaly should be active
+	t.TrendAnomalyActive = t.isTrendsAnomalyActive(Ts)
+	if !t.isTrendsAnomalyActive(Ts) {
+		return 0.0
 	}
 
-	// Define instananous anomalies
-	instantaneousAnomalyDelta := anomaly.instantaneousAnomalyDelta(r)
-	totalAnomalyDelta := trendAnomalyDelta + instantaneousAnomalyDelta
+	// Slope of the trend anomaly in units of magnitude change per second
+	trendSlope := t.TrendAnomalyMagnitude / t.TrendAnomalyDuration
 
-	return totalAnomalyDelta
+	// The duration that we are through the existing trend anomaly in seconds
+	elapsedTrendTime := float64(t.TrendAnomalyIndex) * Ts
+
+	trendAnomalySign := 1.0
+	if !t.IsRisingTrendAnomaly {
+		trendAnomalySign = -1.0
+	}
+
+	trendAnomalyDelta := elapsedTrendTime * trendSlope * trendAnomalySign
+	t.TrendAnomalyIndex += 1
+
+	// If the trend anomaly is complete, reset the index and increment the repeat counter
+	if t.TrendAnomalyIndex == int(t.TrendAnomalyDuration/Ts) {
+		t.TrendAnomalyIndex = 0
+		t.TrendStartIndex = 0
+		t.trendRepeats += 1
+	}
+
+	return trendAnomalyDelta
 }
 
-// Returns the instantaneous anomaly delta. The anomaly is activated based
-// on the probability of an anomaly occuring.
-func (anomaly *Anomaly) instantaneousAnomalyDelta(r *rand.Rand) float64 {
-	instantaneousAnomalyDelta := 0.0
-	anomaly.InstantaneousAnomalyActive = false
-	if anomaly.InstantaneousAnomalyProbability > r.Float64() {
-		instantaneousAnomalyDelta = anomaly.InstantaneousAnomalyMagnitude
-		anomaly.InstantaneousAnomalyActive = true
+// Returns whether the trend anomaly should be active based on it meeting
+// all of the following validity criteria:
+//  1. IsTrendAnomaly is true;
+//  2. TrendAnomalyDuration is not 0;
+//  3. The number of repetitions of the trend has not exceeded the limit, and;
+//  4. The index is within the scope of the anomaly.
+//
+// If the anomaly is active and has not yet started, the index is incremented.
+func (t *TrendAnomaly) isTrendsAnomalyActive(Ts float64) bool {
+	trendsActive := t.IsTrendAnomaly
+	hasNonZeroDuration := t.TrendAnomalyDuration != 0.0
+	repetitionsWithinScope := t.trendRepeats < t.TrendRepetition || t.TrendRepetition == 0
+
+	validTrends := trendsActive && hasNonZeroDuration && repetitionsWithinScope
+
+	if !validTrends {
+		return false
 	}
-	return instantaneousAnomalyDelta
+
+	// Increment the index if the anomaly has not yet started
+	indexWithinScope := t.TrendStartIndex >= int(t.TrendStartDelay/Ts)-1
+	if !indexWithinScope {
+		t.TrendStartIndex += 1
+		return false
+	}
+
+	return true
 }

--- a/anomaly.go
+++ b/anomaly.go
@@ -68,12 +68,11 @@ func (t *TrendAnomaly) getDelta(Ts float64) float64 {
 	// The duration that we are through the existing trend anomaly in seconds
 	elapsedTrendTime := float64(t.TrendAnomalyIndex) * Ts
 
-	trendAnomalySign := 1.0
-	if !t.IsRisingTrendAnomaly {
-		trendAnomalySign = -1.0
-	}
+	// The sign of the trend anomaly based on whether it is a rising or falling trend
+	trendAnomalySign := t.getTrendAnomalySign()
 
 	trendAnomalyDelta := elapsedTrendTime * trendSlope * trendAnomalySign
+
 	t.TrendAnomalyIndex += 1
 
 	// If the trend anomaly is complete, reset the index and increment the repeat counter
@@ -113,4 +112,12 @@ func (t *TrendAnomaly) isTrendsAnomalyActive(Ts float64) bool {
 	}
 
 	return true
+}
+
+// Returns the sign of the trend anomaly based on whether it is a rising or falling trend.
+func (t *TrendAnomaly) getTrendAnomalySign() float64 {
+	if t.IsRisingTrendAnomaly {
+		return 1.0
+	}
+	return -1.0
 }

--- a/anomaly.go
+++ b/anomaly.go
@@ -30,6 +30,16 @@ type Anomaly struct {
 	trendRepeats      int // internal counter for number of times the trend anomaly has repeated
 }
 
+// Steps all anomalies and returns the sum of their effects.
+func stepAllAnomalies(anomalies map[string]*Anomaly, r *rand.Rand, Ts float64) float64 {
+	value := 0.0
+	// Must use indexing so that each anomaly internal state is updated
+	for key := range anomalies {
+		value += anomalies[key].stepAnomaly(r, Ts)
+	}
+	return value
+}
+
 // Returns the change in signal caused by all anomalies this timestep.
 // Ts is the sampling period of the data in seconds, and r is a random number generator.
 func (anomaly *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {

--- a/anomaly.go
+++ b/anomaly.go
@@ -4,24 +4,30 @@ import "math/rand/v2"
 
 type Anomaly struct {
 	// instantaneous anomalies, based on probability factor
-	isInstantaneousAnomaly          bool // private, activated based on probability
-	InstantaneousAnomalyProbability float64
-	InstantaneousAnomalyMagnitude   float64
+	InstantaneousAnomalyProbability float64 `yaml:"InstantaneousAnomalyProbability"` // probability of an instantaneous anomaly in each time step
+	InstantaneousAnomalyMagnitude   float64 `yaml:"InstantaneousAnomalyMagnitude"`   // magnitude of instantaneous anomalies
+	InstantaneousAnomalyActive      bool    // whether an instantaneous anomaly is active in this time step
 
 	// trend anomalies, providing periodic positive or negative slopes of given magnitude and duration
-	IsTrendAnomaly        bool    `yaml:"IsTrendAnomaly"`
-	IsRisingTrendAnomaly  bool    `yaml:"IsRisingTrendAnomaly"`
-	TrendAnomalyDuration  float64 `yaml:"TrendAnomalyDuration"` // duration in seconds
-	TrendStartDelay       float64 `yaml:"TrendStartDelay"`      // duration in seconds
-	TrendStartIndex       int     `yaml:"TrendStartIndex"`      // number of time step ticks
-	TrendAnomalyIndex     int     `yaml:"TrendAnomalyIndex"`    // number of time step ticks
-	TrendAnomalyMagnitude float64 `yaml:"TrendAnomalyMagnitude"`
+	IsTrendAnomaly        bool    `yaml:"IsTrendAnomaly"`        // true to turn trend anomalies on, false to deactivate
+	IsRisingTrendAnomaly  bool    `yaml:"IsRisingTrendAnomaly"`  // true for positive slope, false for negative slope
+	TrendAnomalyDuration  float64 `yaml:"TrendAnomalyDuration"`  // duration of trend anomaly in seconds
+	TrendStartDelay       float64 `yaml:"TrendStartDelay"`       // start time of trend anomaly in seconds
+	TrendStartIndex       int     `yaml:"TrendStartIndex"`       // number of time step ticks
+	TrendAnomalyIndex     int     `yaml:"TrendAnomalyIndex"`     // number of time step ticks
+	TrendAnomalyMagnitude float64 `yaml:"TrendAnomalyMagnitude"` // magnitude of trend anomaly (the maximum height of the slope)
+	TrendRepetition       int     `yaml:"TrendRepetition"`       // number of times the trend anomaly is repeated, default 0 for infinite
+	TrendAnomalyActive    bool    // whether a trend anomaly is active in this time step
+
+	trendRepeats int // counter for number of times the trend anomaly has been repeated
 }
 
 func (anomaly *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {
+	// Define trend anomalies
 	trendAnomalyDelta := 0.0
-
-	if anomaly.IsTrendAnomaly && anomaly.TrendAnomalyDuration > 0.0 {
+	anomaly.TrendAnomalyActive = false
+	if anomaly.IsTrendAnomaly && anomaly.TrendAnomalyDuration > 0.0 && (anomaly.trendRepeats < anomaly.TrendRepetition || anomaly.TrendRepetition == 0) {
+		anomaly.TrendAnomalyActive = true
 		trendAnomalyStep := (anomaly.TrendAnomalyMagnitude / anomaly.TrendAnomalyDuration) * Ts
 
 		if anomaly.TrendStartIndex >= int(anomaly.TrendStartDelay/Ts)-1 {
@@ -34,6 +40,7 @@ func (anomaly *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {
 			if anomaly.TrendAnomalyIndex == int(anomaly.TrendAnomalyDuration/Ts)-1 {
 				anomaly.TrendAnomalyIndex = 0
 				anomaly.TrendStartIndex = 0
+				anomaly.trendRepeats += 1
 			} else {
 				anomaly.TrendAnomalyIndex += 1
 			}
@@ -42,14 +49,21 @@ func (anomaly *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {
 		}
 	}
 
-	instantaneousAnomalyDelta := 0.0
-	anomaly.isInstantaneousAnomaly = false
-	if anomaly.InstantaneousAnomalyProbability > r.Float64() {
-		instantaneousAnomalyDelta = anomaly.InstantaneousAnomalyMagnitude
-		anomaly.isInstantaneousAnomaly = true
-	}
-
+	// Define instananous anomalies
+	instantaneousAnomalyDelta := anomaly.instantaneousAnomalyDelta(r)
 	totalAnomalyDelta := trendAnomalyDelta + instantaneousAnomalyDelta
 
 	return totalAnomalyDelta
+}
+
+// Returns the instantaneous anomaly delta. The anomaly is activated based
+// on the probability of an anomaly occuring.
+func (anomaly *Anomaly) instantaneousAnomalyDelta(r *rand.Rand) float64 {
+	instantaneousAnomalyDelta := 0.0
+	anomaly.InstantaneousAnomalyActive = false
+	if anomaly.InstantaneousAnomalyProbability > r.Float64() {
+		instantaneousAnomalyDelta = anomaly.InstantaneousAnomalyMagnitude
+		anomaly.InstantaneousAnomalyActive = true
+	}
+	return instantaneousAnomalyDelta
 }

--- a/anomaly.go
+++ b/anomaly.go
@@ -30,11 +30,19 @@ type Anomaly struct {
 
 // Define a map between TrendFunction strings and functions
 var trendFunctions = map[string]func(float64, float64, float64) float64{
-	"linear":      linearRamp, // default
-	"sine":        sinusoid,
-	"exponential": exponentialRamp,
-	"square":      squareWave,
-	"sawtooth":    sawtoothWave,
+	"linear":            linearRamp, // default
+	"sine":              sinusoid,
+	"cosine":            cosine,
+	"exponential":       exponentialRamp,
+	"parabolic":         parabolicRamp,
+	"step":              stepFunction,
+	"square":            squareWave,
+	"sawtooth":          sawtoothWave,
+	"impulse":           impulseTrain,
+	"random_noise":      randomNoise,
+	"gaussian_noise":    gaussianNoise,
+	"exponential_noise": exponentialNoise,
+	"random_walk":       randomWalk,
 }
 
 // Returns the change in signal caused by all anomalies this timestep.

--- a/anomaly.go
+++ b/anomaly.go
@@ -52,17 +52,22 @@ func stepAllAnomalies(anomalies AnomalyContainer, r *rand.Rand, Ts float64) floa
 func (a *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {
 	// Set internal state: get the function to use for the trend anomaly if not set
 	if a.trendFunc == nil {
-		trendFunc, err := mathfuncs.GetTrendFunctionFromName(a.TrendFuncName)
-		if err != nil {
-			panic(err)
-		}
-		a.trendFunc = trendFunc
+		a.initTrendFunc()
 	}
 
 	instantaneousAnomalyDelta := a.getInstantaneousDelta(r)
 	trendAnomalyDelta := a.getTrendDelta(Ts)
 
 	return instantaneousAnomalyDelta + trendAnomalyDelta
+}
+
+// Initializes the trend function to use for the trend anomaly.
+func (a *Anomaly) initTrendFunc() {
+	trendFunc, err := mathfuncs.GetTrendFunctionFromName(a.TrendFuncName)
+	if err != nil {
+		panic(err)
+	}
+	a.trendFunc = trendFunc
 }
 
 // Returns the change in signal caused by the instantaneous anomaly this timestep.

--- a/anomaly.go
+++ b/anomaly.go
@@ -2,32 +2,41 @@ package emulator
 
 import "math/rand/v2"
 
+// Anomaly provides combinations of instantaneous and trend anomalies.
 type Anomaly struct {
-	InstantaneousAnomaly
-	TrendAnomaly
+	// InstantaneousAnomaly produces spikes in the data that occur at each timestep based on a probability factor.
+	InstantaneousAnomalyProbability float64 `yaml:"InstantaneousAnomalyProbability"` // probability of instantaneous anomaly in each time step
+	InstantaneousAnomalyMagnitude   float64 `yaml:"InstantaneousAnomalyMagnitude"`   // magnitude of instantaneous anomalies
+	InstantaneousAnomalyActive      bool    // indicates whether an instantaneous anomaly is active in this time step
+
+	// TrendAnomaly provides periodic positive or negative slopes of given magnitude and duration
+	IsTrendAnomaly        bool    `yaml:"IsTrendAnomaly"`        // true: trend anomalies activated, false: deactivated
+	IsRisingTrendAnomaly  bool    `yaml:"IsRisingTrendAnomaly"`  // true: positive slope, false: negative slope
+	TrendAnomalyDuration  float64 `yaml:"TrendAnomalyDuration"`  // duration of each trend anomaly in seconds
+	TrendStartDelay       float64 `yaml:"TrendStartDelay"`       // start time of trend anomalies in seconds
+	TrendAnomalyMagnitude float64 `yaml:"TrendAnomalyMagnitude"` // magnitude of trend anomaly
+	TrendRepetition       int     `yaml:"TrendRepetition"`       // number of times the trend anomaly repeats, default 0 for infinite
+	TrendAnomalyActive    bool    // indicates whether a trend anomaly is active in this time step
+
+	TrendStartIndex   int `yaml:"TrendStartIndex"`   // used internally: TrendStartDelay converted to number of time step ticks
+	TrendAnomalyIndex int `yaml:"TrendAnomalyIndex"` // used internally: number of time step ticks since the start of the last trend anomaly
+	trendRepeats      int // internal counter for number of times the trend anomaly has been repeated
 }
 
 // Calculates the anomaly delta for the current timestep based on all active anomalies. Ts is the sampling
 // period of the data in seconds, and r is a random number generator.
 func (anomaly *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {
-	instantaneousAnomalyDelta := anomaly.InstantaneousAnomaly.getDelta(r)
-	trendAnomalyDelta := anomaly.TrendAnomaly.getDelta(Ts)
+	instantaneousAnomalyDelta := anomaly.getInstantaneousDelta(r)
+	trendAnomalyDelta := anomaly.getTrendDelta(Ts)
 
 	totalAnomalyDelta := trendAnomalyDelta + instantaneousAnomalyDelta
 
 	return totalAnomalyDelta
 }
 
-// InstantaneousAnomaly provides a spike in the temperature based on a probability factor.
-type InstantaneousAnomaly struct {
-	InstantaneousAnomalyProbability float64 `yaml:"InstantaneousAnomalyProbability"` // probability of instantaneous anomaly in each time step
-	InstantaneousAnomalyMagnitude   float64 `yaml:"InstantaneousAnomalyMagnitude"`   // magnitude of instantaneous anomalies
-	InstantaneousAnomalyActive      bool    // whether an instantaneous anomaly is active in this time step
-}
-
-// Returns the instantaneous anomaly delta. The anomaly is activated based
-// by comparing a random number with the probability of an anomaly occuring.
-func (a *InstantaneousAnomaly) getDelta(r *rand.Rand) float64 {
+// Returns the change in signal caused by the instantaneous anomaly this timestep (the delta).
+// The anomaly is activated when its probability factor exceeds a random number.
+func (a *Anomaly) getInstantaneousDelta(r *rand.Rand) float64 {
 	instantaneousAnomalyDelta := 0.0
 	a.InstantaneousAnomalyActive = false
 	if a.InstantaneousAnomalyProbability > r.Float64() {
@@ -37,77 +46,63 @@ func (a *InstantaneousAnomaly) getDelta(r *rand.Rand) float64 {
 	return instantaneousAnomalyDelta
 }
 
-// TrendAnomaly provides periodic positive or negative slopes of given magnitude and duration
-type TrendAnomaly struct {
-	IsTrendAnomaly        bool    `yaml:"IsTrendAnomaly"`        // true to turn trend anomalies on, false to deactivate
-	IsRisingTrendAnomaly  bool    `yaml:"IsRisingTrendAnomaly"`  // true for positive slope, false for negative slope
-	TrendAnomalyDuration  float64 `yaml:"TrendAnomalyDuration"`  // duration of trend anomaly in seconds
-	TrendStartDelay       float64 `yaml:"TrendStartDelay"`       // start time of trend anomaly in seconds
-	TrendStartIndex       int     `yaml:"TrendStartIndex"`       // number of time step ticks
-	TrendAnomalyIndex     int     `yaml:"TrendAnomalyIndex"`     // number of time step ticks
-	TrendAnomalyMagnitude float64 `yaml:"TrendAnomalyMagnitude"` // magnitude of trend anomaly (the maximum height of the slope)
-	TrendRepetition       int     `yaml:"TrendRepetition"`       // number of times the trend anomaly is repeated, default 0 for infinite
-	TrendAnomalyActive    bool    // whether a trend anomaly is active in this time step
-
-	trendRepeats int // internal counter for number of times the trend anomaly has been repeated
-}
-
-// Returns the trend anomaly delta and increments the internal index of the anomaly to
-// track the progress of the anomaly. Ts is the sampling period of the data.
-// The duration and progress of the anomaly is tracked internally.
-func (t *TrendAnomaly) getDelta(Ts float64) float64 {
+// Returns the change in signal caused by the trend anomaly this timestep (the delta),
+// and increments trendAnomalyIndex to track the progress of the trend internally.
+// Ts is the sampling period of the data.
+func (a *Anomaly) getTrendDelta(Ts float64) float64 {
 	// Check if the trend anomaly should be active
-	t.TrendAnomalyActive = t.isTrendsAnomalyActive(Ts)
-	if !t.isTrendsAnomalyActive(Ts) {
+	a.TrendAnomalyActive = a.isTrendsAnomalyActive(Ts)
+	if !a.isTrendsAnomalyActive(Ts) {
 		return 0.0
 	}
 
 	// Slope of the trend anomaly in units of magnitude change per second
-	trendSlope := t.TrendAnomalyMagnitude / t.TrendAnomalyDuration
+	trendSlope := a.TrendAnomalyMagnitude / a.TrendAnomalyDuration
 
 	// The duration that we are through the existing trend anomaly in seconds
-	elapsedTrendTime := float64(t.TrendAnomalyIndex) * Ts
+	elapsedTrendTime := float64(a.TrendAnomalyIndex) * Ts
 
 	// The sign of the trend anomaly based on whether it is a rising or falling trend
-	trendAnomalySign := t.getTrendAnomalySign()
+	trendAnomalySign := a.getTrendAnomalySign()
 
 	trendAnomalyDelta := elapsedTrendTime * trendSlope * trendAnomalySign
 
-	t.TrendAnomalyIndex += 1
+	a.TrendAnomalyIndex += 1
 
 	// If the trend anomaly is complete, reset the index and increment the repeat counter
-	if t.TrendAnomalyIndex == int(t.TrendAnomalyDuration/Ts) {
-		t.TrendAnomalyIndex = 0
-		t.TrendStartIndex = 0
-		t.trendRepeats += 1
+	if a.TrendAnomalyIndex == int(a.TrendAnomalyDuration/Ts) {
+		a.TrendAnomalyIndex = 0
+		a.TrendStartIndex = 0
+		a.trendRepeats += 1
 	}
 
 	return trendAnomalyDelta
 }
 
-// Returns whether the trend anomaly should be active based on it meeting
-// all of the following validity criteria:
-//  1. IsTrendAnomaly is true;
-//  2. TrendAnomalyDuration is not 0;
-//  3. The number of repetitions of the trend has not exceeded the limit, and;
-//  4. The index is within the scope of the anomaly.
+// Returns whether trend anomalies should be active this timestep based on meeting
+// all of the following criteria:
+//  1. IsTrendAnomaly == true;
+//  2. TrendAnomalyDuration != 0;
+//  3. The number of repetitions of the trend has not exceeded TrendRepetition, and;
+//  4. TrendStartDelay has elapsed.
 //
-// If the anomaly is active and has not yet started, the index is incremented.
-func (t *TrendAnomaly) isTrendsAnomalyActive(Ts float64) bool {
-	trendsActive := t.IsTrendAnomaly
-	hasNonZeroDuration := t.TrendAnomalyDuration != 0.0
-	repetitionsWithinScope := t.trendRepeats < t.TrendRepetition || t.TrendRepetition == 0
+// If the anomaly has not yet started, then TrendStartIndex is incremented.
+func (a *Anomaly) isTrendsAnomalyActive(Ts float64) bool {
+	// Start with validity checks
+	isActivated := a.IsTrendAnomaly
+	hasNonZeroDuration := a.TrendAnomalyDuration != 0.0
+	moreRepeatsAllowed := a.trendRepeats < a.TrendRepetition || a.TrendRepetition == 0
 
-	validTrends := trendsActive && hasNonZeroDuration && repetitionsWithinScope
+	isValid := isActivated && hasNonZeroDuration && moreRepeatsAllowed
 
-	if !validTrends {
+	if !isValid {
 		return false
 	}
 
-	// Increment the index if the anomaly has not yet started
-	indexWithinScope := t.TrendStartIndex >= int(t.TrendStartDelay/Ts)-1
+	// Increment TrendStartIndex if the anomaly has not yet started
+	indexWithinScope := a.TrendStartIndex >= int(a.TrendStartDelay/Ts)-1
 	if !indexWithinScope {
-		t.TrendStartIndex += 1
+		a.TrendStartIndex += 1
 		return false
 	}
 
@@ -115,8 +110,8 @@ func (t *TrendAnomaly) isTrendsAnomalyActive(Ts float64) bool {
 }
 
 // Returns the sign of the trend anomaly based on whether it is a rising or falling trend.
-func (t *TrendAnomaly) getTrendAnomalySign() float64 {
-	if t.IsRisingTrendAnomaly {
+func (a *Anomaly) getTrendAnomalySign() float64 {
+	if a.IsRisingTrendAnomaly {
 		return 1.0
 	}
 	return -1.0

--- a/anomaly.go
+++ b/anomaly.go
@@ -2,6 +2,8 @@ package emulator
 
 import (
 	"math/rand/v2"
+
+	"github.com/synaptecltd/emulator/mathfuncs"
 )
 
 // Anomaly provides combinations of instantaneous and trend anomalies.
@@ -26,23 +28,6 @@ type Anomaly struct {
 	TrendStartIndex   int `yaml:"TrendStartIndex"`   // TrendStartDelay converted to number of time steps
 	TrendAnomalyIndex int `yaml:"TrendAnomalyIndex"` // number of time steps since the start of the last trend anomaly
 	trendRepeats      int // internal counter for number of times the trend anomaly has repeated
-}
-
-// Define a map between TrendFunction strings and functions
-var trendFunctions = map[string]func(float64, float64, float64) float64{
-	"linear":            linearRamp, // default
-	"sine":              sinusoid,
-	"cosine":            cosine,
-	"exponential":       exponentialRamp,
-	"parabolic":         parabolicRamp,
-	"step":              stepFunction,
-	"square":            squareWave,
-	"sawtooth":          sawtoothWave,
-	"impulse":           impulseTrain,
-	"random_noise":      randomNoise,
-	"gaussian_noise":    gaussianNoise,
-	"exponential_noise": exponentialNoise,
-	"random_walk":       randomWalk,
 }
 
 // Returns the change in signal caused by all anomalies this timestep.
@@ -82,10 +67,9 @@ func (a *Anomaly) getTrendDelta(Ts float64) float64 {
 	elapsedTrendTime := float64(a.TrendAnomalyIndex) * Ts
 
 	// Get the function to use for the trend anomaly
-	trendFunc, ok := trendFunctions[a.TrendFunction]
-	if !ok {
-		// Default to linear ramp if the function is not found in the map
-		trendFunc = linearRamp
+	trendFunc, err := mathfuncs.GetTrendFunctionFromName(a.TrendFunction)
+	if err != nil {
+		panic(err)
 	}
 
 	trendAnomalyMagnitude := trendFunc(elapsedTrendTime, a.TrendAnomalyMagnitude, a.TrendAnomalyDuration)

--- a/anomaly.go
+++ b/anomaly.go
@@ -20,8 +20,8 @@ type Anomaly struct {
 	TrendRepetition       int     `yaml:"TrendRepetition"`       // number of times the trend anomaly repeats, default 0 for infinite
 	TrendAnomalyActive    bool    // indicates whether trend anomaly is active in this time step
 
-	TrendStartIndex   int `yaml:"TrendStartIndex"`   // used internally: TrendStartDelay converted to number of time step ticks
-	TrendAnomalyIndex int `yaml:"TrendAnomalyIndex"` // used internally: number of time step ticks since the start of the last trend anomaly
+	TrendStartIndex   int `yaml:"TrendStartIndex"`   // TrendStartDelay converted to number of time steps
+	TrendAnomalyIndex int `yaml:"TrendAnomalyIndex"` // number of time steps since the start of the last trend anomaly
 	trendRepeats      int // internal counter for number of times the trend anomaly has repeated
 }
 

--- a/anomaly.go
+++ b/anomaly.go
@@ -22,7 +22,7 @@ type Anomaly struct {
 	TrendStartDelay       float64 `yaml:"TrendStartDelay"`       // start time of trend anomalies in seconds
 	TrendAnomalyMagnitude float64 `yaml:"TrendAnomalyMagnitude"` // magnitude of trend anomaly
 	TrendRepetition       int     `yaml:"TrendRepetition"`       // number of times the trend anomaly repeats, default 0 for infinite
-	TrendFunction         string  `yaml:"TrendFunction"`         // function to use for the trend anomaly, defaults to linear
+	TrendFuncName         string  `yaml:"TrendFunction"`         // name of function to use for the trend anomaly, defaults to linear ramp if empty
 	TrendAnomalyActive    bool    // indicates whether trend anomaly is active in this time step
 
 	TrendStartIndex   int `yaml:"TrendStartIndex"`   // TrendStartDelay converted to number of time steps
@@ -67,7 +67,7 @@ func (a *Anomaly) getTrendDelta(Ts float64) float64 {
 	elapsedTrendTime := float64(a.TrendAnomalyIndex) * Ts
 
 	// Get the function to use for the trend anomaly
-	trendFunc, err := mathfuncs.GetTrendFunctionFromName(a.TrendFunction)
+	trendFunc, err := mathfuncs.GetTrendFunctionFromName(a.TrendFuncName)
 	if err != nil {
 		panic(err)
 	}

--- a/anomaly.go
+++ b/anomaly.go
@@ -3,28 +3,30 @@ package emulator
 import "math/rand/v2"
 
 // Anomaly provides combinations of instantaneous and trend anomalies.
+//   - InstantaneousAnomaly produces spikes in the data that occur at each timestep based on a probability factor.
+//   - TrendAnomaly provides periodic positive or negative slopes of given magnitude and duration
 type Anomaly struct {
-	// InstantaneousAnomaly produces spikes in the data that occur at each timestep based on a probability factor.
+	// Instantaneous anomalies
 	InstantaneousAnomalyProbability float64 `yaml:"InstantaneousAnomalyProbability"` // probability of instantaneous anomaly in each time step
 	InstantaneousAnomalyMagnitude   float64 `yaml:"InstantaneousAnomalyMagnitude"`   // magnitude of instantaneous anomalies
-	InstantaneousAnomalyActive      bool    // indicates whether an instantaneous anomaly is active in this time step
+	InstantaneousAnomalyActive      bool    // indicates whether instantaneous anomaly is active in this time step
 
-	// TrendAnomaly provides periodic positive or negative slopes of given magnitude and duration
+	// Trend anomalies
 	IsTrendAnomaly        bool    `yaml:"IsTrendAnomaly"`        // true: trend anomalies activated, false: deactivated
 	IsRisingTrendAnomaly  bool    `yaml:"IsRisingTrendAnomaly"`  // true: positive slope, false: negative slope
 	TrendAnomalyDuration  float64 `yaml:"TrendAnomalyDuration"`  // duration of each trend anomaly in seconds
 	TrendStartDelay       float64 `yaml:"TrendStartDelay"`       // start time of trend anomalies in seconds
 	TrendAnomalyMagnitude float64 `yaml:"TrendAnomalyMagnitude"` // magnitude of trend anomaly
 	TrendRepetition       int     `yaml:"TrendRepetition"`       // number of times the trend anomaly repeats, default 0 for infinite
-	TrendAnomalyActive    bool    // indicates whether a trend anomaly is active in this time step
+	TrendAnomalyActive    bool    // indicates whether trend anomaly is active in this time step
 
 	TrendStartIndex   int `yaml:"TrendStartIndex"`   // used internally: TrendStartDelay converted to number of time step ticks
 	TrendAnomalyIndex int `yaml:"TrendAnomalyIndex"` // used internally: number of time step ticks since the start of the last trend anomaly
-	trendRepeats      int // internal counter for number of times the trend anomaly has been repeated
+	trendRepeats      int // internal counter for number of times the trend anomaly has repeated
 }
 
-// Calculates the anomaly delta for the current timestep based on all active anomalies. Ts is the sampling
-// period of the data in seconds, and r is a random number generator.
+// Returns the change in signal caused by all anomalies this timestep.
+// Ts is the sampling period of the data in seconds, and r is a random number generator.
 func (anomaly *Anomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {
 	instantaneousAnomalyDelta := anomaly.getInstantaneousDelta(r)
 	trendAnomalyDelta := anomaly.getTrendDelta(Ts)

--- a/emulator.go
+++ b/emulator.go
@@ -87,6 +87,8 @@ func (e *Emulator) StartEvent(eventType int) {
 	}
 }
 
+// Returns a new Emulator instance with a given sampling rate and frequency.
+// The emulator's random seed is initialized with a random value.
 func NewEmulator(samplingRate int, frequency float64) *Emulator {
 	emu := &Emulator{
 		SamplingRate: samplingRate,
@@ -98,6 +100,12 @@ func NewEmulator(samplingRate int, frequency float64) *Emulator {
 	emu.r = rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 
 	return emu
+}
+
+// Sets the random seed for the emulator. This is useful for
+// generating identical random events across multiple runs.
+func (e *Emulator) SetRandomSeed(seed uint64) {
+	e.r = rand.New(rand.NewPCG(seed, seed))
 }
 
 // Step performs one iteration of the waveform generation for the given time step, Ts

--- a/emulator.go
+++ b/emulator.go
@@ -32,7 +32,7 @@ const EmulatedFaultCurrentMagnitude = 80
 type Emulator struct {
 	// common inputs
 	SamplingRate int     `yaml:"SamplingRate"` // The sampling rate of the emulator
-	Ts           float64 `yaml:"Ts"`           // The time step for a given sampling rate
+	Ts           float64 `yaml:"Ts"`           // The time step or sampling period (=1/SamplingRate)
 	Fnom         float64 `yaml:"Fnom"`         // Nominal frequency
 	Fdeviation   float64 `yaml:"Fdeviation"`   // Frequency deviation
 

--- a/emulator.go
+++ b/emulator.go
@@ -102,8 +102,8 @@ func NewEmulator(samplingRate int, frequency float64) *Emulator {
 	return emu
 }
 
-// Sets the random seed for the emulator. This is useful for
-// generating identical random events across multiple runs.
+// Sets the random seed for the emulator. This can be used to
+// generate identical random events across multiple runs.
 func (e *Emulator) SetRandomSeed(seed uint64) {
 	e.r = rand.New(rand.NewPCG(seed, seed))
 }

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -43,11 +43,6 @@ func createEmulatorForBenchmark(samplingRate int, phaseOffsetDeg float64) *Emula
 func createEmulator(samplingRate int, phaseOffsetDeg float64) *Emulator {
 	emu := NewEmulator(samplingRate, 50.0)
 
-	anomaly := Anomaly{
-		InstantaneousAnomalyMagnitude:   30,
-		InstantaneousAnomalyProbability: 0.01,
-	}
-
 	emu.V = &ThreePhaseEmulation{
 		PosSeqMag:   400000.0 / math.Sqrt(3) * math.Sqrt(2),
 		NoiseMax:    0.000001,
@@ -65,7 +60,10 @@ func createEmulator(samplingRate int, phaseOffsetDeg float64) *Emulator {
 		MeanTemperature: 30.0,
 		NoiseMax:        0.01,
 		Anomaly: AnomalyContainer{
-			anomalyKey: &anomaly,
+			anomalyKey: {
+				InstantaneousAnomalyMagnitude:   30,
+				InstantaneousAnomalyProbability: 0.01,
+			},
 		},
 	}
 	return emu

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -64,7 +64,7 @@ func createEmulator(samplingRate int, phaseOffsetDeg float64) *Emulator {
 	emu.T = &TemperatureEmulation{
 		MeanTemperature: 30.0,
 		NoiseMax:        0.01,
-		Anomaly: map[string]*Anomaly{
+		Anomaly: AnomalyContainer{
 			anomalyKey: &anomaly,
 		},
 	}
@@ -77,7 +77,7 @@ func createEmulatorForAnomaly(samplingRate int) *Emulator {
 	emu.I = &ThreePhaseEmulation{
 		PosSeqMag:   350.0,
 		PhaseOffset: 0.0,
-		PosSeqMagAnomaly: map[string]*Anomaly{
+		PosSeqMagAnomaly: AnomalyContainer{
 			anomalyKey: {
 				IsTrendAnomaly:        true,
 				IsRisingTrendAnomaly:  true,

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -103,7 +103,7 @@ func TestTemperatureEmulationAnomalies_NoAnomalies(t *testing.T) {
 	var results []bool
 	for step < 1e4 {
 		emulator.Step()
-		results = append(results, emulator.T.Anomaly.isInstantaneousAnomaly)
+		results = append(results, emulator.T.Anomaly.InstantaneousAnomalyActive)
 		step += 1
 	}
 	assert.NotContains(t, results, true)
@@ -119,9 +119,9 @@ func TestTemperatureEmulationAnomalies_Anomalies(t *testing.T) {
 	var anomalyValues []float64
 	for step < 1e4 {
 		emulator.Step()
-		results = append(results, emulator.T.Anomaly.isInstantaneousAnomaly)
+		results = append(results, emulator.T.Anomaly.InstantaneousAnomalyActive)
 
-		if emulator.T.Anomaly.isInstantaneousAnomaly == true {
+		if emulator.T.Anomaly.InstantaneousAnomalyActive == true {
 			anomalyValues = append(anomalyValues, emulator.T.T)
 		} else {
 			normalValues = append(normalValues, emulator.T.T)

--- a/mathfuncs/mathsfuncs.go
+++ b/mathfuncs/mathsfuncs.go
@@ -118,14 +118,26 @@ func exponentialNoise(_, A, _ float64) float64 {
 	return -A * math.Log(rand.Float64())
 }
 
-// Returns a random walk of amplitude A every period T.
+// Returns a random walk that lasts for period T. The walk is bounded
+// to within +/- amplitude A, and can make steps of maximum size A/20.
 // The returned function is stateful, it remembers the previous value.
 // This prevents stack overflow errors that occur with recursive implementations.
 var randomWalk = func() func(float64, float64, float64) float64 {
+	stepFactor := 20.0
 	var previousValue float64 = 0
 	return func(t, A, T float64) float64 {
 		if t != 0 {
-			previousValue += A * (rand.Float64()*2 - 1)
+			step := A / stepFactor * (rand.Float64()*2 - 1)
+			proposedValue := previousValue + step
+
+			// Hold the value within the bounds of +/- A
+			if proposedValue > A {
+				previousValue = A
+			} else if proposedValue < -A {
+				previousValue = -A
+			} else {
+				previousValue = proposedValue
+			}
 		}
 		return previousValue
 	}

--- a/mathfuncs/mathsfuncs.go
+++ b/mathfuncs/mathsfuncs.go
@@ -6,11 +6,15 @@ import (
 	"math/rand/v2"
 )
 
-// A map between string names and functions
-var trendFunctions = map[string]func(float64, float64, float64) float64{
+// A mathematical function y=f(t,A,T). Takes amplitude, A, and period, T,
+// as inputs and returns the value of the function at time, t.
+type TrendFunction func(t, A, T float64) float64
+
+// A map between string name and trendFunction pairs
+var trendFunctions = map[string]TrendFunction{
 	"linear":            linearRamp, // default
-	"sine":              sinusoid,
-	"cosine":            cosine,
+	"sine":              sineWave,
+	"cosine":            cosineWave,
 	"exponential":       exponentialRamp,
 	"parabolic":         parabolicRamp,
 	"step":              stepFunction,
@@ -24,7 +28,7 @@ var trendFunctions = map[string]func(float64, float64, float64) float64{
 }
 
 // Returns the named trend function. Defaults to linear if name is empty.
-func GetTrendFunctionFromName(name string) (func(float64, float64, float64) float64, error) {
+func GetTrendFunctionFromName(name string) (TrendFunction, error) {
 	// Default to linear if no name is provided
 	if name == "" {
 		return trendFunctions["linear"], nil
@@ -44,15 +48,15 @@ func linearRamp(t, A, T float64) float64 {
 	return m * t
 }
 
-// Returns a sinusoid y=A*sin(2*pi*t/T) where A is the amplitude,
+// Returns a sine wave y=A*sin(2*pi*t/T) where A is the amplitude,
 // T is the period, and t is elapsed time.
-func sinusoid(t, A, T float64) float64 {
+func sineWave(t, A, T float64) float64 {
 	return A * math.Sin(2*math.Pi*t/T)
 }
 
 // Returns a cosine wave y=A*cos(2*pi*t/T) where A is the amplitude,
 // T is the period, and t is elapsed time.
-func cosine(t, A, T float64) float64 {
+func cosineWave(t, A, T float64) float64 {
 	return A * math.Cos(2*math.Pi*t/T)
 }
 

--- a/mathfuncs/mathsfuncs.go
+++ b/mathfuncs/mathsfuncs.go
@@ -21,6 +21,7 @@ var trendFunctions = map[string]TrendFunction{
 	"square":            squareWave,
 	"sawtooth":          sawtoothWave,
 	"impulse":           impulseTrain,
+	"impulse_varying":   impulseTrainVaryingMagnitude,
 	"random_noise":      randomNoise,
 	"gaussian_noise":    gaussianNoise,
 	"exponential_noise": exponentialNoise,
@@ -105,6 +106,13 @@ func impulseTrain(t, A, T float64) float64 {
 	} else {
 		return 0
 	}
+}
+
+// Returns a spike every period T, with an amplitude which is
+// normally distributed about A. Each spike has a width of 1 microsecond.
+func impulseTrainVaryingMagnitude(t, A, T float64) float64 {
+	fixedAmplitudeImpulse := impulseTrain(t, A, T)
+	return fixedAmplitudeImpulse * rand.NormFloat64()
 }
 
 // Returns additional random (uniform) noise of amplitude A.

--- a/mathfuncs/mathsfuncs.go
+++ b/mathfuncs/mathsfuncs.go
@@ -1,9 +1,41 @@
-package emulator
+package mathfuncs
 
 import (
+	"errors"
 	"math"
 	"math/rand/v2"
 )
+
+// A map between string names and functions
+var trendFunctions = map[string]func(float64, float64, float64) float64{
+	"linear":            linearRamp, // default
+	"sine":              sinusoid,
+	"cosine":            cosine,
+	"exponential":       exponentialRamp,
+	"parabolic":         parabolicRamp,
+	"step":              stepFunction,
+	"square":            squareWave,
+	"sawtooth":          sawtoothWave,
+	"impulse":           impulseTrain,
+	"random_noise":      randomNoise,
+	"gaussian_noise":    gaussianNoise,
+	"exponential_noise": exponentialNoise,
+	"random_walk":       randomWalk,
+}
+
+// Returns the named trend function. Defaults to linear if name is empty.
+func GetTrendFunctionFromName(name string) (func(float64, float64, float64) float64, error) {
+	// Default to linear if no name is provided
+	if name == "" {
+		return trendFunctions["linear"], nil
+	}
+	trendFunc, ok := trendFunctions[name]
+	if !ok {
+		return nil, errors.New("trend function not found")
+	}
+
+	return trendFunc, nil
+}
 
 // Returns a linear ramp y=(A/T)*t where A is the magntiude of the ramp, T is
 // its duration, and t is elapsed time.

--- a/mathfuncs/mathsfuncs_test.go
+++ b/mathfuncs/mathsfuncs_test.go
@@ -11,9 +11,11 @@ import (
 
 // Tests for non-random trend functions
 func TestDeterministicTrendFunctions(t *testing.T) {
+	M := 1.0 + rand.Float64()*99.0 // ampltiude (between 1 and 100)
+	x := 1.0 + rand.Float64()*99.0 // time (between 1 and 100)
+
 	testCases := []struct {
-		name     string // name of the function, defined in the TrendFunctions map
-		function func(float64, float64, float64) float64
+		name     string  // name of the function, defined in the TrendFunctions map
 		t        float64 // time in seconds
 		A        float64 // amplitude
 		T        float64 // period of the trend in seconds
@@ -21,107 +23,111 @@ func TestDeterministicTrendFunctions(t *testing.T) {
 		isError  bool    // true if an error is expected
 	}{
 		{
+			name:    "not_a_function",
+			isError: true,
+		},
+		{
 			name:     "linear",
-			t:        2.0,
-			A:        3.0,
-			T:        3.0,
-			expected: 2.0, // y = (3/3)*2 = 2
+			t:        x,
+			A:        M,
+			T:        M,
+			expected: x, // y = (A/A)*x = x
 			isError:  false,
 		},
 		{
 			name:     "sine",
-			t:        0.5,
-			A:        5.0,
-			T:        2,
-			expected: 5.0, // A*sin(2*pi*0.5/2) = 5
+			t:        x,
+			A:        M,
+			T:        4 * x,
+			expected: M, // M*sin(2*pi*(x/4x)) = M*sin(pi/2) = M
 			isError:  false,
 		},
 		{
 			name:     "cosine",
-			t:        0.5,
-			A:        5.0,
-			T:        2.0,
-			expected: 0.0, // A*cos(2*pi*0.5/2) = 0
+			t:        x,
+			A:        M,
+			T:        4 * x,
+			expected: 0.0, // M*cos(pi/2) = 0
 			isError:  false,
 		},
 		{
 			name:     "exponential",
-			t:        1.0,
-			A:        2.0,
-			T:        1.0,
-			expected: 2*math.Exp(1) - 2, // A*exp(1) - A = 2*exp(1) - 2
+			t:        x,
+			A:        M,
+			T:        x,
+			expected: M*math.Exp(1) - M, // because M*exp(t/T) = M*exp(1)
 			isError:  false,
 		},
 		{
 			name:     "parabolic",
-			t:        1.0,
-			A:        4.0,
-			T:        2.0,
-			expected: 1.0, // A*(1/2)^2 = 4*(1/4) = 1
+			t:        x,
+			A:        M,
+			T:        2 * x,
+			expected: M / 4, // M*(x/2x)^2 = M*(1/2)^2 = M/4
 			isError:  false,
 		},
 		{
 			name:     "step",
-			t:        1.5,
-			A:        6.0,
-			T:        2.0,
-			expected: 6.0, // positive value for t > T/2
+			t:        1.5 * x,
+			A:        M,
+			T:        2.0 * x,
+			expected: M, // positive value for t > T/2
 			isError:  false,
 		},
 		{
 			name:     "step",
 			t:        0.0,
-			A:        6.0,
-			T:        2.0,
+			A:        M,
+			T:        x,
 			expected: 0.0, // zero value for t < T/2
 			isError:  false,
 		},
 		{
 			name:     "square",
 			t:        0.0,
-			A:        6.0,
-			T:        2.0,
-			expected: 6.0, // positive value for sin >= 0
+			A:        M,
+			T:        x,
+			expected: M, // positive value for t=0
 			isError:  false,
 		},
 		{
 			name:     "square",
-			t:        1.5,
-			A:        6.0,
-			T:        2.0,
-			expected: -6.0, // negative value for sin < 0
+			t:        1.5 * x,
+			A:        M,
+			T:        2.0 * x,
+			expected: -M, // negative value for t > T/2
 			isError:  false,
 		},
 		{
 			name:     "sawtooth",
-			t:        5.0,
-			A:        10.0,
-			T:        1.0,
-			expected: 0.0, // middle of sawtooth wave
+			t:        3.0 * x,
+			A:        M,
+			T:        x,
+			expected: 0.0, // odd numbered factors of time period = middle of sawtooth wave
 			isError:  false,
 		},
 		{
 			name:     "sawtooth",
-			t:        2.5,
-			A:        10.0,
-			T:        10.0,
-			expected: 5.0, // half way up the sawtooth wave A/2
+			t:        x,
+			A:        M,
+			T:        4 * x,
+			expected: M / 2, // quarter of time period = half way up the sawtooth wave
 			isError:  false,
 		},
 		{
 			name:     "impulse",
-			t:        0.5,
-			A:        100.0,
-			T:        10.0,
-			expected: 0.0, // no impulse at t=0.5
+			t:        x / 2.0,
+			A:        M,
+			T:        x,
+			expected: 0.0, // no impulse when t != T
 			isError:  false,
 		},
 		{
 			name:     "impulse",
-			t:        10.0,
-			A:        100.0,
-			T:        10.0,
-			expected: 100.0, // impulse at t=10
+			t:        x,
+			A:        M,
+			T:        x,
+			expected: M, // impulse at t==T
 			isError:  false,
 		},
 		// Add more test cases for other trend functions
@@ -229,9 +235,9 @@ func TestNoiseFunctions(t *testing.T) {
 				mean := sum / float64(tc.numSamples)
 				variance := sumSq/float64(tc.numSamples) - mean*mean
 				stddev := math.Sqrt(variance)
-				// Low value of 0.01 used for the delta: non-exact values due to small sample sizes
-				assert.InDelta(t, tc.expectedMean, mean, 0.01)
-				assert.InDelta(t, tc.expectedStdDev, stddev, 0.01)
+				// Low value of 0.1 used for the delta: non-exact values due to small sample sizes
+				assert.InDelta(t, tc.expectedMean, mean, 0.1)
+				assert.InDelta(t, tc.expectedStdDev, stddev, 0.1)
 			}
 		})
 	}

--- a/mathfuncs/mathsfuncs_test.go
+++ b/mathfuncs/mathsfuncs_test.go
@@ -1,0 +1,54 @@
+package mathfuncs
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTrendFunctions(t *testing.T) {
+	testCases := []struct {
+		name     string // name of the function, defined in the TrendFunctions map
+		function func(float64, float64, float64) float64
+		t        float64 // time in seconds
+		A        float64 // amplitude
+		T        float64 // period in seconds
+		expected float64 // expected value of the function at time t
+	}{
+		{
+			name:     "linear",
+			function: TrendFunctions["linear"],
+			t:        2.0,
+			A:        1.0,
+			T:        3.0,
+			expected: 5.0,
+		},
+		{
+			name:     "sine",
+			function: TrendFunctions["sine"],
+			t:        math.Pi / 2,
+			A:        0.0,
+			T:        1.0,
+			expected: 1.0,
+		},
+		{
+			name:     "cosine",
+			function: TrendFunctions["cosine"],
+			t:        math.Pi / 2,
+			A:        0.0,
+			T:        1.0,
+			expected: 0.0,
+		},
+		// Add more test cases for other trend functions
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// get the function from the name
+
+			result := tc.function(tc.t, tc.A, tc.T)
+			if result != tc.expected {
+				t.Errorf("Expected %f, but got %f", tc.expected, result)
+			}
+		})
+	}
+}

--- a/mathfuncs/mathsfuncs_test.go
+++ b/mathfuncs/mathsfuncs_test.go
@@ -153,6 +153,8 @@ func TestDeterministicTrendFunctions(t *testing.T) {
 // Tests for non-deteministic trend functions
 func TestNoiseFunctions(t *testing.T) {
 	A := 1.0 + rand.Float64()*9.0 // ampltiude of noise (between 1 and 10)
+	nSamples := int(1e6)          // default number of samples to generate for statistics tests
+	allowedDelta := 0.1           // allowed absolute difference between expected values and results for statistics tests
 
 	type TestCase struct {
 		name            string  // name of the function, defined in the TrendFunctions map
@@ -170,7 +172,7 @@ func TestNoiseFunctions(t *testing.T) {
 	testCases := []TestCase{
 		{
 			name:            "random_noise",
-			numSamples:      1e6,
+			numSamples:      nSamples,
 			checkStatistics: true,
 			expectedMean:    0,                // by definition of uniform distribution
 			expectedStdDev:  A / math.Sqrt(3), // by definition of uniform distribution
@@ -181,7 +183,7 @@ func TestNoiseFunctions(t *testing.T) {
 		},
 		{
 			name:            "gaussian_noise",
-			numSamples:      1e6,
+			numSamples:      nSamples,
 			checkStatistics: true,
 			expectedMean:    0, // by definition of normal distribution
 			expectedStdDev:  A, // by definition of normal distribution
@@ -190,7 +192,7 @@ func TestNoiseFunctions(t *testing.T) {
 		},
 		{
 			name:            "exponential_noise",
-			numSamples:      1e6,
+			numSamples:      nSamples,
 			checkStatistics: true,
 			expectedMean:    A, // by definition of exponential distribution
 			expectedStdDev:  A, // by definition of exponential distribution
@@ -235,9 +237,10 @@ func TestNoiseFunctions(t *testing.T) {
 				mean := sum / float64(tc.numSamples)
 				variance := sumSq/float64(tc.numSamples) - mean*mean
 				stddev := math.Sqrt(variance)
-				// Low value of 0.1 used for the delta: non-exact values due to small sample sizes
-				assert.InDelta(t, tc.expectedMean, mean, 0.1)
-				assert.InDelta(t, tc.expectedStdDev, stddev, 0.1)
+				// Non-exact values due to small sample sizes, so use high values of allowed
+				// delta to prevent random test failures
+				assert.InDelta(t, tc.expectedMean, mean, allowedDelta)
+				assert.InDelta(t, tc.expectedStdDev, stddev, allowedDelta)
 			}
 		})
 	}

--- a/mathfuncs/mathsfuncs_test.go
+++ b/mathfuncs/mathsfuncs_test.go
@@ -1,42 +1,128 @@
-package mathfuncs
+package mathfuncs_test
 
 import (
 	"math"
+	"math/rand/v2"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/synaptecltd/emulator/mathfuncs"
 )
 
-func TestTrendFunctions(t *testing.T) {
+// Tests for non-random trend functions
+func TestDeterministicTrendFunctions(t *testing.T) {
 	testCases := []struct {
 		name     string // name of the function, defined in the TrendFunctions map
 		function func(float64, float64, float64) float64
 		t        float64 // time in seconds
 		A        float64 // amplitude
-		T        float64 // period in seconds
+		T        float64 // period of the trend in seconds
 		expected float64 // expected value of the function at time t
+		isError  bool    // true if an error is expected
 	}{
 		{
 			name:     "linear",
-			function: TrendFunctions["linear"],
 			t:        2.0,
-			A:        1.0,
+			A:        3.0,
 			T:        3.0,
-			expected: 5.0,
+			expected: 2.0, // y = (3/3)*2 = 2
+			isError:  false,
 		},
 		{
 			name:     "sine",
-			function: TrendFunctions["sine"],
-			t:        math.Pi / 2,
-			A:        0.0,
-			T:        1.0,
-			expected: 1.0,
+			t:        0.5,
+			A:        5.0,
+			T:        2,
+			expected: 5.0, // A*sin(2*pi*0.5/2) = 5
+			isError:  false,
 		},
 		{
 			name:     "cosine",
-			function: TrendFunctions["cosine"],
-			t:        math.Pi / 2,
-			A:        0.0,
+			t:        0.5,
+			A:        5.0,
+			T:        2.0,
+			expected: 0.0, // A*cos(2*pi*0.5/2) = 0
+			isError:  false,
+		},
+		{
+			name:     "exponential",
+			t:        1.0,
+			A:        2.0,
 			T:        1.0,
-			expected: 0.0,
+			expected: 2*math.Exp(1) - 2, // A*exp(1) - A = 2*exp(1) - 2
+			isError:  false,
+		},
+		{
+			name:     "parabolic",
+			t:        1.0,
+			A:        4.0,
+			T:        2.0,
+			expected: 1.0, // A*(1/2)^2 = 4*(1/4) = 1
+			isError:  false,
+		},
+		{
+			name:     "step",
+			t:        1.5,
+			A:        6.0,
+			T:        2.0,
+			expected: 6.0, // positive value for t > T/2
+			isError:  false,
+		},
+		{
+			name:     "step",
+			t:        0.0,
+			A:        6.0,
+			T:        2.0,
+			expected: 0.0, // zero value for t < T/2
+			isError:  false,
+		},
+		{
+			name:     "square",
+			t:        0.0,
+			A:        6.0,
+			T:        2.0,
+			expected: 6.0, // positive value for sin >= 0
+			isError:  false,
+		},
+		{
+			name:     "square",
+			t:        1.5,
+			A:        6.0,
+			T:        2.0,
+			expected: -6.0, // negative value for sin < 0
+			isError:  false,
+		},
+		{
+			name:     "sawtooth",
+			t:        5.0,
+			A:        10.0,
+			T:        1.0,
+			expected: 0.0, // middle of sawtooth wave
+			isError:  false,
+		},
+		{
+			name:     "sawtooth",
+			t:        2.5,
+			A:        10.0,
+			T:        10.0,
+			expected: 5.0, // half way up the sawtooth wave A/2
+			isError:  false,
+		},
+		{
+			name:     "impulse",
+			t:        0.5,
+			A:        100.0,
+			T:        10.0,
+			expected: 0.0, // no impulse at t=0.5
+			isError:  false,
+		},
+		{
+			name:     "impulse",
+			t:        10.0,
+			A:        100.0,
+			T:        10.0,
+			expected: 100.0, // impulse at t=10
+			isError:  false,
 		},
 		// Add more test cases for other trend functions
 	}
@@ -44,10 +130,108 @@ func TestTrendFunctions(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// get the function from the name
+			testFunction, err := mathfuncs.GetTrendFunctionFromName(tc.name)
 
-			result := tc.function(tc.t, tc.A, tc.T)
-			if result != tc.expected {
-				t.Errorf("Expected %f, but got %f", tc.expected, result)
+			if tc.isError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			result := testFunction(tc.t, tc.A, tc.T)
+			assert.InDelta(t, tc.expected, result, 1e-6)
+		})
+	}
+}
+
+// Tests for non-deteministic trend functions
+func TestNoiseFunctions(t *testing.T) {
+	A := 1.0 + rand.Float64()*9.0 // ampltiude of noise (between 1 and 10)
+
+	type TestCase struct {
+		name            string  // name of the function, defined in the TrendFunctions map
+		numSamples      int     // number of samples of noise to generate, generate at least 1e6 samples if checking statistics
+		checkStatistics bool    // whether test should check the mean and standard deviation of the noise
+		expectedMean    float64 // expected mean of the noise
+		expectedStdDev  float64 // expected standard deviation of the noise
+		checkBounds     bool    // whether to check the bounds of the noise
+		lowerBound      float64 // lower bound of the noise
+		upperBound      float64 // upper bound of the noise
+		checkStepSize   bool    // whether to check the change in noise from one sample to the next
+		maxStepSize     float64 // maximum step size allowed
+	}
+
+	testCases := []TestCase{
+		{
+			name:            "random_noise",
+			numSamples:      1e6,
+			checkStatistics: true,
+			expectedMean:    0,
+			expectedStdDev:  A / math.Sqrt(3),
+			checkBounds:     true,
+			lowerBound:      -A,
+			upperBound:      A,
+			checkStepSize:   false,
+		},
+		{
+			name:            "gaussian_noise",
+			numSamples:      1e6,
+			checkStatistics: true,
+			expectedMean:    0,
+			expectedStdDev:  A,
+			checkBounds:     false,
+			checkStepSize:   false,
+		},
+		{
+			name:            "exponential_noise",
+			numSamples:      1e6,
+			checkStatistics: true,
+			expectedMean:    A,
+			expectedStdDev:  A,
+			checkBounds:     true,
+			lowerBound:      0,
+			upperBound:      math.Inf(1),
+			checkStepSize:   false,
+		},
+		{
+			name:            "random_walk",
+			numSamples:      100, // statistics not being checked so fewer samples required
+			checkStatistics: false,
+			checkBounds:     true,
+			lowerBound:      -A,
+			upperBound:      A,
+			checkStepSize:   true,
+			maxStepSize:     A / 20.0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testFunction, err := mathfuncs.GetTrendFunctionFromName(tc.name)
+			assert.NoError(t, err)
+
+			var sum, sumSq float64
+			var prevValue float64
+			for i := 0; i < tc.numSamples; i++ {
+				x := testFunction(float64(i), A, 0)
+				if tc.checkBounds {
+					assert.True(t, x >= tc.lowerBound && x <= tc.upperBound, "value out of bounds")
+				}
+				if tc.checkStepSize {
+					assert.True(t, math.Abs(x-prevValue) <= tc.maxStepSize, "step size larger than max step size")
+				}
+				sum += x
+				sumSq += x * x
+				prevValue = x
+			}
+
+			if tc.checkStatistics {
+				mean := sum / float64(tc.numSamples)
+				variance := sumSq/float64(tc.numSamples) - mean*mean
+				stddev := math.Sqrt(variance)
+				// Low value of 0.01 used for the delta: non-exact values due to small sample sizes
+				assert.InDelta(t, tc.expectedMean, mean, 0.01)
+				assert.InDelta(t, tc.expectedStdDev, stddev, 0.01)
 			}
 		})
 	}

--- a/mathfuncs/mathsfuncs_test.go
+++ b/mathfuncs/mathsfuncs_test.go
@@ -130,6 +130,14 @@ func TestDeterministicTrendFunctions(t *testing.T) {
 			expected: M, // impulse at t==T
 			isError:  false,
 		},
+		{
+			name:     "impulse_varying",
+			t:        x / 2.0,
+			A:        M,
+			T:        x,
+			expected: 0.0, // no impulse when t!=T
+			isError:  false,
+		},
 		// Add more test cases for other trend functions
 	}
 

--- a/mathfuncs/mathsfuncs_test.go
+++ b/mathfuncs/mathsfuncs_test.go
@@ -163,8 +163,8 @@ func TestNoiseFunctions(t *testing.T) {
 		checkBounds     bool    // whether to check the bounds of the noise
 		lowerBound      float64 // lower bound of the noise
 		upperBound      float64 // upper bound of the noise
-		checkStepSize   bool    // whether to check the change in noise from one sample to the next
-		maxStepSize     float64 // maximum step size allowed
+		checkNoiseDelta bool    // whether to check the change in noise from one sample to the next
+		maxDelta        float64 // maximum change in noise allowed between samples
 	}
 
 	testCases := []TestCase{
@@ -172,42 +172,42 @@ func TestNoiseFunctions(t *testing.T) {
 			name:            "random_noise",
 			numSamples:      1e6,
 			checkStatistics: true,
-			expectedMean:    0,
-			expectedStdDev:  A / math.Sqrt(3),
+			expectedMean:    0,                // by definition of uniform distribution
+			expectedStdDev:  A / math.Sqrt(3), // by definition of uniform distribution
 			checkBounds:     true,
 			lowerBound:      -A,
 			upperBound:      A,
-			checkStepSize:   false,
+			checkNoiseDelta: false,
 		},
 		{
 			name:            "gaussian_noise",
 			numSamples:      1e6,
 			checkStatistics: true,
-			expectedMean:    0,
-			expectedStdDev:  A,
+			expectedMean:    0, // by definition of normal distribution
+			expectedStdDev:  A, // by definition of normal distribution
 			checkBounds:     false,
-			checkStepSize:   false,
+			checkNoiseDelta: false,
 		},
 		{
 			name:            "exponential_noise",
 			numSamples:      1e6,
 			checkStatistics: true,
-			expectedMean:    A,
-			expectedStdDev:  A,
+			expectedMean:    A, // by definition of exponential distribution
+			expectedStdDev:  A, // by definition of exponential distribution
 			checkBounds:     true,
-			lowerBound:      0,
-			upperBound:      math.Inf(1),
-			checkStepSize:   false,
+			lowerBound:      0,           // exponential distribution always non-negative values
+			upperBound:      math.Inf(1), // exponential distribution is unbounded at the upper end
+			checkNoiseDelta: false,
 		},
 		{
 			name:            "random_walk",
 			numSamples:      100, // statistics not being checked so fewer samples required
 			checkStatistics: false,
 			checkBounds:     true,
-			lowerBound:      -A,
+			lowerBound:      -A, // bounds are defined within mathfuncs.randomWalk
 			upperBound:      A,
-			checkStepSize:   true,
-			maxStepSize:     A / 20.0,
+			checkNoiseDelta: true,
+			maxDelta:        A / 20.0, // maximum step size is defined within mathfuncs.randomWalk
 		},
 	}
 
@@ -223,8 +223,8 @@ func TestNoiseFunctions(t *testing.T) {
 				if tc.checkBounds {
 					assert.True(t, x >= tc.lowerBound && x <= tc.upperBound, "value out of bounds")
 				}
-				if tc.checkStepSize {
-					assert.True(t, math.Abs(x-prevValue) <= tc.maxStepSize, "step size larger than max step size")
+				if tc.checkNoiseDelta {
+					assert.True(t, math.Abs(x-prevValue) <= tc.maxDelta, "step size larger than max step size")
 				}
 				sum += x
 				sumSq += x * x

--- a/mathsfuncs.go
+++ b/mathsfuncs.go
@@ -1,0 +1,38 @@
+package emulator
+
+import "math"
+
+// Returns the magntiude of a linear ramp y=(A/T)*t where A is the magntiude of the ramp, T is
+// its duration, and t is elapsed time.
+func linearRamp(t float64, A float64, T float64) float64 {
+	m := A / T // slope of the ramp
+	return m * t
+}
+
+// Returns the magnitude of a sinusoid y=A*sin(2*pi*t/T) where A is the amplitude,
+// T is the period, and t is elapsed time.
+func sinusoid(t float64, A float64, T float64) float64 {
+	return A * math.Sin(2*math.Pi*t/T)
+}
+
+// Returns the magnitude of an exponential ramp y=A*exp(t/T) - A where A is the amplitude,
+// T is the time constant, and t is elapsed time.
+func exponentialRamp(t, A, T float64) float64 {
+	return A*math.Exp(t/T) - A
+}
+
+// Returns the magnitude of a square wave y=A if sin(2*pi*t/T) >= 0, else -A.
+// where A is the amplitude, T is the period, and t is elapsed time.
+func squareWave(t, A, T float64) float64 {
+	if math.Sin(2*math.Pi*t/T) >= 0 {
+		return A
+	} else {
+		return -A
+	}
+}
+
+// Returns the magnitude of a sawtooth wave y=(2*A/pi)*atan(tan(pi*t/T)),
+// where A is the amplitude, T is the period, and t is elapsed time.
+func sawtoothWave(t, A, T float64) float64 {
+	return (2 * A / math.Pi) * math.Atan(math.Tan(math.Pi*t/T))
+}

--- a/mathsfuncs.go
+++ b/mathsfuncs.go
@@ -1,27 +1,50 @@
 package emulator
 
-import "math"
+import (
+	"math"
+	"math/rand/v2"
+)
 
-// Returns the magntiude of a linear ramp y=(A/T)*t where A is the magntiude of the ramp, T is
+// Returns a linear ramp y=(A/T)*t where A is the magntiude of the ramp, T is
 // its duration, and t is elapsed time.
-func linearRamp(t float64, A float64, T float64) float64 {
+func linearRamp(t, A, T float64) float64 {
 	m := A / T // slope of the ramp
 	return m * t
 }
 
-// Returns the magnitude of a sinusoid y=A*sin(2*pi*t/T) where A is the amplitude,
+// Returns a sinusoid y=A*sin(2*pi*t/T) where A is the amplitude,
 // T is the period, and t is elapsed time.
-func sinusoid(t float64, A float64, T float64) float64 {
+func sinusoid(t, A, T float64) float64 {
 	return A * math.Sin(2*math.Pi*t/T)
 }
 
-// Returns the magnitude of an exponential ramp y=A*exp(t/T) - A where A is the amplitude,
+// Returns a cosine wave y=A*cos(2*pi*t/T) where A is the amplitude,
+// T is the period, and t is elapsed time.
+func cosine(t, A, T float64) float64 {
+	return A * math.Cos(2*math.Pi*t/T)
+}
+
+// Returns an exponential ramp y=A*exp(t/T) - A where A is the amplitude,
 // T is the time constant, and t is elapsed time.
 func exponentialRamp(t, A, T float64) float64 {
 	return A*math.Exp(t/T) - A
 }
 
-// Returns the magnitude of a square wave y=A if sin(2*pi*t/T) >= 0, else -A.
+// Returns a parabolic ramp of amplitude A every period T.
+func parabolicRamp(t, A, T float64) float64 {
+	return A * math.Pow(t/T, 2)
+}
+
+// Returns a step function of amplitude A every period T.
+func stepFunction(t, A, T float64) float64 {
+	if math.Mod(t, T) < T/2 {
+		return 0
+	} else {
+		return A
+	}
+}
+
+// Returns a square wave y=A if sin(2*pi*t/T) >= 0, else -A.
 // where A is the amplitude, T is the period, and t is elapsed time.
 func squareWave(t, A, T float64) float64 {
 	if math.Sin(2*math.Pi*t/T) >= 0 {
@@ -31,8 +54,47 @@ func squareWave(t, A, T float64) float64 {
 	}
 }
 
-// Returns the magnitude of a sawtooth wave y=(2*A/pi)*atan(tan(pi*t/T)),
+// Returns a sawtooth wave y=(2*A/pi)*atan(tan(pi*t/T)),
 // where A is the amplitude, T is the period, and t is elapsed time.
 func sawtoothWave(t, A, T float64) float64 {
 	return (2 * A / math.Pi) * math.Atan(math.Tan(math.Pi*t/T))
 }
+
+// Returns a spike of amplitude A every period T.
+// Each spike has a width of 1 microsecond.
+func impulseTrain(t, A, T float64) float64 {
+	spikeWidth := 1e-6
+	if math.Mod(t, T) < spikeWidth {
+		return A
+	} else {
+		return 0
+	}
+}
+
+// Returns additional random (uniform) noise of amplitude A.
+func randomNoise(_, A, _ float64) float64 {
+	return A * (rand.Float64()*2 - 1) // A random number between -A and A
+}
+
+// Returns additional Gaussian noise of amplitude A.
+func gaussianNoise(_, A, _ float64) float64 {
+	return rand.NormFloat64() * A
+}
+
+// Returns additional exponential noise of amplitude A.
+func exponentialNoise(_, A, _ float64) float64 {
+	return -A * math.Log(rand.Float64())
+}
+
+// Returns a random walk of amplitude A every period T.
+// The returned function is stateful, it remembers the previous value.
+// This prevents stack overflow errors that occur with recursive implementations.
+var randomWalk = func() func(float64, float64, float64) float64 {
+	var previousValue float64 = 0
+	return func(t, A, T float64) float64 {
+		if t != 0 {
+			previousValue += A * (rand.Float64()*2 - 1)
+		}
+		return previousValue
+	}
+}()

--- a/temperature.go
+++ b/temperature.go
@@ -5,17 +5,17 @@ import (
 )
 
 type TemperatureEmulation struct {
-	MeanTemperature float64 `yaml:"MeanTemperature"` // mean temperature
-	NoiseMax        float64 `yaml:"NoiseMax"`        // magnitude of Gaussian noise
-
-	Anomaly Anomaly `yaml:"Anomaly"` // anomalies
-
-	T float64 `yaml:"-"` // present value of temperature
+	MeanTemperature float64             `yaml:"MeanTemperature"` // mean temperature
+	NoiseMax        float64             `yaml:"NoiseMax"`        // magnitude of Gaussian noise
+	Anomaly         map[string]*Anomaly `yaml:"Anomalies"`       // anomalies
+	T               float64             `yaml:"-"`               // present value of temperature
 }
 
 // Steps the temperature emulation forward by one time step. The new temperature is
 // calculated as the mean temperature + Gaussian noise + anomalies (if present).
 func (t *TemperatureEmulation) stepTemperature(r *rand.Rand, Ts float64) {
-	totalAnomalyDelta := t.Anomaly.stepAnomaly(r, Ts)
-	t.T = t.MeanTemperature + r.NormFloat64()*t.NoiseMax*t.MeanTemperature + totalAnomalyDelta
+	t.T = t.MeanTemperature + r.NormFloat64()*t.NoiseMax*t.MeanTemperature
+
+	anomalyValues := stepAllAnomalies(t.Anomaly, r, Ts)
+	t.T += anomalyValues
 }

--- a/temperature.go
+++ b/temperature.go
@@ -1,24 +1,21 @@
 package emulator
 
 import (
-	"math"
 	"math/rand/v2"
 )
 
 type TemperatureEmulation struct {
-	MeanTemperature float64 `yaml:"MeanTemperature"`         // Mean temperature
-	NoiseMax        float64 `yaml:"NoiseMax"`                // Maximum noise
-	ModulationMag   float64 `yaml:"ModulationMag,omitempty"` // Magnitude modulation
+	MeanTemperature float64 `yaml:"MeanTemperature"` // mean temperature
+	NoiseMax        float64 `yaml:"NoiseMax"`        // magnitude of Gaussian noise
 
-	Anomaly Anomaly `yaml:"Anomaly"` // Anomaly
+	Anomaly Anomaly `yaml:"Anomaly"` // anomalies
 
-	T float64 `yaml:"-"`
+	T float64 `yaml:"-"` // present value of temperature
 }
 
+// Steps the temperature emulation forward by one time step. The new temperature is
+// calculated as the mean temperature + Gaussian noise + anomalies (if present).
 func (t *TemperatureEmulation) stepTemperature(r *rand.Rand, Ts float64) {
-	varyingT := t.MeanTemperature * (1 + t.ModulationMag*math.Cos(1000.0*Ts))
-
 	totalAnomalyDelta := t.Anomaly.stepAnomaly(r, Ts)
-
-	t.T = varyingT + r.NormFloat64()*t.NoiseMax*t.MeanTemperature + totalAnomalyDelta
+	t.T = t.MeanTemperature + r.NormFloat64()*t.NoiseMax*t.MeanTemperature + totalAnomalyDelta
 }

--- a/temperature.go
+++ b/temperature.go
@@ -5,10 +5,10 @@ import (
 )
 
 type TemperatureEmulation struct {
-	MeanTemperature float64             `yaml:"MeanTemperature"` // mean temperature
-	NoiseMax        float64             `yaml:"NoiseMax"`        // magnitude of Gaussian noise
-	Anomaly         map[string]*Anomaly `yaml:"Anomalies"`       // anomalies
-	T               float64             `yaml:"-"`               // present value of temperature
+	MeanTemperature float64          `yaml:"MeanTemperature"` // mean temperature
+	NoiseMax        float64          `yaml:"NoiseMax"`        // magnitude of Gaussian noise
+	Anomaly         AnomalyContainer `yaml:"Anomaly"`         // anomalies
+	T               float64          `yaml:"-"`               // present value of temperature
 }
 
 // Steps the temperature emulation forward by one time step. The new temperature is

--- a/threephase.go
+++ b/threephase.go
@@ -11,16 +11,16 @@ const TwoPiOverThree = 2 * math.Pi / 3
 
 type ThreePhaseEmulation struct {
 	// inputs
-	PosSeqMag       float64   `yaml:"PosSeqMag"`                      // Positive Sequence Magnitude
-	PhaseOffset     float64   `yaml:"PhaseOffset,omitempty"`          // Phase Offset
-	NegSeqMag       float64   `yaml:"NegSeqMag,omitempty"`            // Negative Sequence Magnitude
-	NegSeqAng       float64   `yaml:"NegSeqAng,omitempty"`            // Negative Sequence Angle
-	ZeroSeqMag      float64   `yaml:"ZeroSeqMag,omitempty"`           // Zero Sequence Magnitude
-	ZeroSeqAng      float64   `yaml:"ZeroSeqAng,omitempty"`           // Zero Sequence Angle
-	HarmonicNumbers []float64 `yaml:"HarmonicNumbers,flow,omitempty"` // Harmonic Numbers
-	HarmonicMags    []float64 `yaml:"HarmonicMags,flow,omitempty"`    // Harmonic magnitudes in pu, relative to PosSeqMag
-	HarmonicAngs    []float64 `yaml:"HarmonicAngs,flow,omitempty"`    // Harmonic Angles
-	NoiseMax        float64   `yaml:"NoiseMax,omitempty"`             // Maximum noise (Gaussian)
+	PosSeqMag       float64   `yaml:"PosSeqMag"`                      // positive Sequence Magnitude
+	PhaseOffset     float64   `yaml:"PhaseOffset,omitempty"`          // phase Offset
+	NegSeqMag       float64   `yaml:"NegSeqMag,omitempty"`            // negative Sequence Magnitude
+	NegSeqAng       float64   `yaml:"NegSeqAng,omitempty"`            // negative Sequence Angle
+	ZeroSeqMag      float64   `yaml:"ZeroSeqMag,omitempty"`           // zero Sequence Magnitude
+	ZeroSeqAng      float64   `yaml:"ZeroSeqAng,omitempty"`           // zero Sequence Angle
+	HarmonicNumbers []float64 `yaml:"HarmonicNumbers,flow,omitempty"` // harmonic Numbers
+	HarmonicMags    []float64 `yaml:"HarmonicMags,flow,omitempty"`    // harmonic magnitudes in pu, relative to PosSeqMag
+	HarmonicAngs    []float64 `yaml:"HarmonicAngs,flow,omitempty"`    // harmonic Angles
+	NoiseMax        float64   `yaml:"NoiseMax,omitempty"`             // magnitude of Gaussian noise
 
 	// define anomalies
 	PosSeqMagAnomaly Anomaly // positive sequence magnitude anomaly
@@ -45,6 +45,8 @@ type ThreePhaseEmulation struct {
 	A, B, C float64 `yaml:"-"`
 }
 
+// Steps the three phase emulation forward by one time step. The new values are
+// defined based on magntiudes, noise values, anomalies and fault conditions.
 func (e *ThreePhaseEmulation) stepThreePhase(r *rand.Rand, f float64, Ts float64, smpCnt int) {
 	// frequency anomaly
 	totalAnomalyDeltaFrequency := e.FreqAnomaly.stepAnomaly(r, Ts)
@@ -124,6 +126,7 @@ func (e *ThreePhaseEmulation) stepThreePhase(r *rand.Rand, f float64, Ts float64
 	e.C = c1 + c2 + abc0 + ch + rc
 }
 
+// Wraps the angle a to the range -pi to pi
 func wrapAngle(a float64) float64 {
 	if a > math.Pi {
 		return a - 2*math.Pi

--- a/threephase.go
+++ b/threephase.go
@@ -11,15 +11,15 @@ const TwoPiOverThree = 2 * math.Pi / 3
 
 type ThreePhaseEmulation struct {
 	// inputs
-	PosSeqMag       float64   `yaml:"PosSeqMag"`                      // positive Sequence Magnitude
-	PhaseOffset     float64   `yaml:"PhaseOffset,omitempty"`          // phase Offset
-	NegSeqMag       float64   `yaml:"NegSeqMag,omitempty"`            // negative Sequence Magnitude
-	NegSeqAng       float64   `yaml:"NegSeqAng,omitempty"`            // negative Sequence Angle
-	ZeroSeqMag      float64   `yaml:"ZeroSeqMag,omitempty"`           // zero Sequence Magnitude
-	ZeroSeqAng      float64   `yaml:"ZeroSeqAng,omitempty"`           // zero Sequence Angle
-	HarmonicNumbers []float64 `yaml:"HarmonicNumbers,flow,omitempty"` // harmonic Numbers
+	PosSeqMag       float64   `yaml:"PosSeqMag"`                      // positive sequence magnitude
+	PhaseOffset     float64   `yaml:"PhaseOffset,omitempty"`          // phase offset
+	NegSeqMag       float64   `yaml:"NegSeqMag,omitempty"`            // negative sequence magnitude
+	NegSeqAng       float64   `yaml:"NegSeqAng,omitempty"`            // negative sequence angle
+	ZeroSeqMag      float64   `yaml:"ZeroSeqMag,omitempty"`           // zero sequence magnitude
+	ZeroSeqAng      float64   `yaml:"ZeroSeqAng,omitempty"`           // zero sequence angle
+	HarmonicNumbers []float64 `yaml:"HarmonicNumbers,flow,omitempty"` // harmonic numbers
 	HarmonicMags    []float64 `yaml:"HarmonicMags,flow,omitempty"`    // harmonic magnitudes in pu, relative to PosSeqMag
-	HarmonicAngs    []float64 `yaml:"HarmonicAngs,flow,omitempty"`    // harmonic Angles
+	HarmonicAngs    []float64 `yaml:"HarmonicAngs,flow,omitempty"`    // harmonic angles
 	NoiseMax        float64   `yaml:"NoiseMax,omitempty"`             // magnitude of Gaussian noise
 
 	// define anomalies

--- a/threephase.go
+++ b/threephase.go
@@ -23,11 +23,11 @@ type ThreePhaseEmulation struct {
 	NoiseMax        float64   `yaml:"NoiseMax,omitempty"`             // magnitude of Gaussian noise
 
 	// define anomalies
-	PosSeqMagAnomaly map[string]*Anomaly // positive sequence magnitude anomaly
-	PosSeqAngAnomaly map[string]*Anomaly // positive sequence angle anomaly
-	PhaseAMagAnomaly map[string]*Anomaly // phase A magnitude anomaly
-	FreqAnomaly      map[string]*Anomaly // frequency anomaly
-	HarmonicsAnomaly map[string]*Anomaly // harmonics magnitude anomaly
+	PosSeqMagAnomaly AnomalyContainer // positive sequence magnitude anomaly
+	PosSeqAngAnomaly AnomalyContainer // positive sequence angle anomaly
+	PhaseAMagAnomaly AnomalyContainer // phase A magnitude anomaly
+	FreqAnomaly      AnomalyContainer // frequency anomaly
+	HarmonicsAnomaly AnomalyContainer // harmonics magnitude anomaly
 
 	// event emulation
 	FaultPhaseAMag        float64 `yaml:"-"`

--- a/threephase.go
+++ b/threephase.go
@@ -20,7 +20,7 @@ type ThreePhaseEmulation struct {
 	HarmonicNumbers []float64 `yaml:"HarmonicNumbers,flow,omitempty"` // Harmonic Numbers
 	HarmonicMags    []float64 `yaml:"HarmonicMags,flow,omitempty"`    // Harmonic magnitudes in pu, relative to PosSeqMag
 	HarmonicAngs    []float64 `yaml:"HarmonicAngs,flow,omitempty"`    // Harmonic Angles
-	NoiseMax        float64   `yaml:"NoiseMax,omitempty"`             // Maximum noise
+	NoiseMax        float64   `yaml:"NoiseMax,omitempty"`             // Maximum noise (Gaussian)
 
 	// define anomalies
 	PosSeqMagAnomaly Anomaly // positive sequence magnitude anomaly


### PR DESCRIPTION
## Summary

This PR allows multiple concurrent anomalies to be defined for an emulator. It also adds new types of anomaly.

Here is an example of a temperature trace with the following combination:
- a ramp anomaly that occurs only once after 0.1 s;
- a sine wave anomaly that repeats indefinitely, and;
- instantaneous spikes of varying magnitude.

![image](https://github.com/synaptecltd/emulator/assets/33428786/2bf953e6-acdc-4e35-92e5-e8313d27c93b)

## Major changes

As the emulator package is open source, and may be used in lots of places, I've kept the methods of defining of emulators and anomalies as fixed as possible, sometimes at the expense of improvements that could be made (listed in the "Changes that were not made" section below).

Defaults are also set up to minimise changes to old code: e.g. when the new fields of an anomaly struct aren't set, the anomaly reverts to old behaviour (e.g. use an indefinitely repeating ramp with fixed-magnitude instantaneous anomalies).

The only major difference is that anomalies for an emulator must be defined as a group, rather than a single anomaly. This is a large change that will break old code, but it's worth it to define concurrent trend anomalies.

The [readme](https://github.com/synaptecltd/emulator/blob/extend/README.md) shows how anomalies must now be defined with an `AnomalyContainer`.

An AnomalyContainer is defined internally as map between strings and anomaly structs. I've opted for a map instead of a slice because it allows for human-readable or traceable (e.g. UUID) indexing and definition of anomalies.

For definitions in yaml, anomaly key-value pairs would now need to be defined as, e.g.:

```yaml
Anomaly:
  simple_ramp:
    IsTrendAnomaly: true
    // other params
  another_anomaly:
    IsTrendAnomaly: true
    // other params
```

The clearest way to see the impact of these changes on old code is to look at `emulator_test.go` or `threephase.go`. These two have had minimal changes in this PR --- the only changes made are to make them compatible with the new definition of anomalies.

If you accept this PR then I'll create another issue to update the emulator in our other code bases and fix any breakages

## Overview of new trend functions

New functions for trends are defined using strings, the default when no string is defined is "linear" (original behaviour). All strings and functions are defined and tested under `./mathfuncs`.

I've plotted the new functions below. For all of these examples:
- the baseline signal is at 30 degC;
- instantaneous anomalies are not activated;
- the trend anomaly start delay is set to 0.1 s;
- the trend anomaly duration (its period) is 0.2s;
- the magnitude of the anomaly is 10 degC, and;
- the anomaly repeats indefinitely (default behaviour that can now be changed).


### Linear, exponential and parabolic ramps

![image](https://github.com/synaptecltd/emulator/assets/33428786/99207c06-0cee-41d7-a83c-bf6dfc5c2c30)

![image](https://github.com/synaptecltd/emulator/assets/33428786/b6edef08-f714-4387-8494-790fd0b3f2c5)

![image](https://github.com/synaptecltd/emulator/assets/33428786/5b3a40b5-70a5-411b-9646-f31195c93605)


### Sine (or cosine)

![image](https://github.com/synaptecltd/emulator/assets/33428786/cbcfa763-0437-418a-8655-6bdcaef20345)
 

### Step, square and sawtooth waves

![image](https://github.com/synaptecltd/emulator/assets/33428786/279c890b-a6b7-45e3-9c12-4f0af67de87b)

![image](https://github.com/synaptecltd/emulator/assets/33428786/b2fea324-598f-4889-af8c-8c1d210db471)

![image](https://github.com/synaptecltd/emulator/assets/33428786/cb218021-f901-44e9-ba4e-74fe7eaf7f1b)


### Periodic impulses: fixed and varying magnitude

![image](https://github.com/synaptecltd/emulator/assets/33428786/12a8a1ff-f9a0-451d-9ef0-15751b248e6a)

![image](https://github.com/synaptecltd/emulator/assets/33428786/426a2620-8115-4fcc-879c-8f27e1c31522)

### Noise bursts: random, Gaussian, and exponential noise

![image](https://github.com/synaptecltd/emulator/assets/33428786/1e19383f-1f78-4f9b-9853-1ff1d306c742)

![image](https://github.com/synaptecltd/emulator/assets/33428786/34186e28-815c-4992-926c-9ad7bf043a25)

![image](https://github.com/synaptecltd/emulator/assets/33428786/9f6618f1-bfe2-4a6f-9f3e-03e37f2c9434)


### Random walk (confined to +/- amplitude)

![image](https://github.com/synaptecltd/emulator/assets/33428786/12437f6e-49b2-4b3d-9d4e-dec410014d15)


## Other smaller changes

- You can now use a new method `SetRandomSeed()` to fix the random seed of the emulator. This allows you to get repeatable "random" anomalies for testing and dev.
- As we can now define multiple concurrent anomalies, the `TemperatureEmulation` struct no longer needs a `ModulationMag` field. ModulationMag originally added a slow sine wave modulation to the data, with a fixed period of 1000 times the sampling rate. Now we can do the same, and more flexibly, with trend anomalies.


## Changes that were not made

The following changes could be implemented, and may improve code readability. They weren't made because it would break old code. They can be implemented if requested.

### Refactor Anomalies

TrendAnomalies and InstantaneousAnomalies could be separated into to two separate structs that are embedded in Anomaly for readability.

The reason I didn't do this is because it would change how anomalies are defined, affecting backward compatibility.

e.g. currently:

```go
	Anomaly := emulator.Anomaly{
		IsTrendAnomaly:       true,
		IsRisingTrendAnomaly: true,
		TrendAnomalyDuration: 0.2,
		TrendStartDelay:      0.1,
	}
```

would need to become:

```go
	Anomaly := emulator.Anomaly{
		emulator.TrendAnomaly{
			IsTrendAnomaly:       true,
			IsRisingTrendAnomaly: true,
			TrendAnomalyDuration: 0.2,
			TrendStartDelay:      0.1,
		},
	}
```


### Misnomer

The name NoiseMax in e.g. TemperatureEmulation:

```go
type TemperatureEmulation struct {
	MeanTemperature float64 `yaml:"MeanTemperature"` // mean temperature
	NoiseMax        float64 `yaml:"NoiseMax"`        // maximum noise (Gaussian)

	Anomaly Anomaly `yaml:"Anomaly"` // anomalies

	T float64 `yaml:"-"` // present value of temperature
}

```
is a misnomer. It's not a maximum noise, it's a scaling factor for Gaussian noise. I haven't changed this because it would impact how old emulator yamls are read.

### Constructor functions

I've avoided constructor functions when they would sometimes be helpful for initialising fixed fields within anomaly structs. Instead, I've used a check every single timestep to see if the values are initialised.

This is clunky, but it is backwards compatible. I could write constructor functions for defining anomalies in code, and via yaml.

