### PR TITLE
Methods to cast anomalies to concrete types

### DIFF
--- a/anomaly/anomaly.go
+++ b/anomaly/anomaly.go
@@ -32,6 +32,18 @@ type AnomalyInterface interface {
 	stepAnomaly(r *rand.Rand, Ts float64) float64 // Steps the internal time state of an anomaly and returns the change in signal caused by the anomaly
 }
 
+// Attempts to cast an AnomalyInterface to a trendAnomaly. Returns the anomaly as a trendAnomaly and boolean indicating success.
+func AsTrendAnomaly(a AnomalyInterface) (*trendAnomaly, bool) {
+	trendAnomaly, ok := a.(*trendAnomaly)
+	return trendAnomaly, ok
+}
+
+// Attempts to cast an AnomalyInterface to a SpikeAnomaly. Returns the anomaly as a SpikeAnomaly and boolean indicating success.
+func AsSpikeAnomaly(a AnomalyInterface) (*spikeAnomaly, bool) {
+	spikeAnomaly, ok := a.(*spikeAnomaly)
+	return spikeAnomaly, ok
+}
+
 // Unmarshals a generic anomaly entry into the correct type base on the anomaly "Type" field.
 func (c *Container) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Create the container if passed an empty pointer

--- a/anomaly/anomaly.go
+++ b/anomaly/anomaly.go
@@ -38,7 +38,7 @@ func AsTrendAnomaly(a AnomalyInterface) (*trendAnomaly, bool) {
 	return trendAnomaly, ok
 }
 
-// Attempts to cast an AnomalyInterface to a SpikeAnomaly. Returns the anomaly as a SpikeAnomaly and boolean indicating success.
+// Attempts to cast an AnomalyInterface to a spikeAnomaly. Returns the anomaly as a spikeAnomaly and boolean indicating success.
 func AsSpikeAnomaly(a AnomalyInterface) (*spikeAnomaly, bool) {
 	spikeAnomaly, ok := a.(*spikeAnomaly)
 	return spikeAnomaly, ok

--- a/anomaly/anomaly_test.go
+++ b/anomaly/anomaly_test.go
@@ -67,3 +67,29 @@ func TestGetTypeAsString(t *testing.T) {
 	expected = "trend"
 	assert.Equal(t, expected, trendAnomaly.GetTypeAsString())
 }
+
+// Test converting AnomalyInterface to trendAnomaly
+func TestAsTrendAnomaly(t *testing.T) {
+	trendAnomaly, _ := anomaly.NewTrendAnomaly(anomaly.TrendParams{})
+	result, ok := anomaly.AsTrendAnomaly(trendAnomaly)
+	assert.True(t, ok)
+	assert.NotNil(t, result)
+
+	spikeAnomaly, _ := anomaly.NewSpikeAnomaly(anomaly.SpikeParams{})
+	result, ok = anomaly.AsTrendAnomaly(spikeAnomaly)
+	assert.False(t, ok)
+	assert.Nil(t, result)
+}
+
+// Test converting AnomalyInterface to spikeAnomaly
+func TestAsSpikeAnomaly(t *testing.T) {
+	trendAnomaly, _ := anomaly.NewTrendAnomaly(anomaly.TrendParams{})
+	result, ok := anomaly.AsSpikeAnomaly(trendAnomaly)
+	assert.False(t, ok)
+	assert.Nil(t, result)
+
+	spikeAnomaly, _ := anomaly.NewSpikeAnomaly(anomaly.SpikeParams{})
+	result, ok = anomaly.AsSpikeAnomaly(spikeAnomaly)
+	assert.True(t, ok)
+	assert.NotNil(t, result)
+}


### PR DESCRIPTION
Require a couple of methods to cast anomalyInterfaces to concrete types so that I can update them using http requests.