### PR TITLE
Update yaml tags

### DIFF
--- a/anomaly/trend.go
+++ b/anomaly/trend.go
@@ -23,7 +23,7 @@ type trendAnomaly struct {
 type TrendParams struct {
 	// Defined in AnomalyBase
 
-	Repeats    uint64  `yaml:"Repeat"`     // the number of times the trend anomaly repeats, 0 for infinite
+	Repeats    uint64  `yaml:"Repeats"`    // the number of times the trend anomaly repeats, 0 for infinite
 	Off        bool    `yaml:"Off"`        // true: anomaly deactivated, false: activated
 	StartDelay float64 `yaml:"StartDelay"` // the delay before trend anomalies begin (and between anomaly repeats) in seconds
 	Duration   float64 `yaml:"Duration"`   // the duration of each trend anomaly in seconds, 0 for continuous

--- a/emulator.go
+++ b/emulator.go
@@ -57,21 +57,21 @@ func (e *Emulator) StartEvent(eventType int) {
 		// TODO
 		// e.I.FaultPosSeqMag = EmulatedFaultCurrentMagnitude
 		// e.I.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
-		e.I.FaultPhaseAMag = e.I.PosSeqMag * 1.2 // EmulatedFaultCurrentMagnitude
-		e.I.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
-		e.V.FaultPhaseAMag = e.V.PosSeqMag * -0.2
-		e.V.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
+		e.I.faultPhaseAMag = e.I.PosSeqMag * 1.2 // EmulatedFaultCurrentMagnitude
+		e.I.faultRemainingSamples = MaxEmulatedFaultDurationSamples
+		e.V.faultPhaseAMag = e.V.PosSeqMag * -0.2
+		e.V.faultRemainingSamples = MaxEmulatedFaultDurationSamples
 	case ThreePhaseFault:
-		e.I.FaultPosSeqMag = e.I.PosSeqMag * 1.2 // EmulatedFaultCurrentMagnitude
-		e.I.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
-		e.V.FaultPosSeqMag = e.V.PosSeqMag * -0.2
-		e.V.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
+		e.I.faultPosSeqMag = e.I.PosSeqMag * 1.2 // EmulatedFaultCurrentMagnitude
+		e.I.faultRemainingSamples = MaxEmulatedFaultDurationSamples
+		e.V.faultPosSeqMag = e.V.PosSeqMag * -0.2
+		e.V.faultRemainingSamples = MaxEmulatedFaultDurationSamples
 	case OverVoltage:
-		e.V.FaultPosSeqMag = e.V.PosSeqMag * 0.2
-		e.V.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
+		e.V.faultPosSeqMag = e.V.PosSeqMag * 0.2
+		e.V.faultRemainingSamples = MaxEmulatedFaultDurationSamples
 	case UnderVoltage:
-		e.V.FaultPosSeqMag = e.V.PosSeqMag * -0.2
-		e.V.FaultRemainingSamples = MaxEmulatedFaultDurationSamples
+		e.V.faultPosSeqMag = e.V.PosSeqMag * -0.2
+		e.V.faultRemainingSamples = MaxEmulatedFaultDurationSamples
 	case OverFrequency:
 		e.Fdeviation = 0.1
 		e.fDeviationRemainingSamples = MaxEmulatedFrequencyDurationSamples
@@ -80,8 +80,8 @@ func (e *Emulator) StartEvent(eventType int) {
 		e.fDeviationRemainingSamples = MaxEmulatedFrequencyDurationSamples
 	case CapacitorOverCurrent:
 		// TODO
-		e.I.FaultPosSeqMag = e.I.PosSeqMag * 0.01
-		e.I.FaultRemainingSamples = MaxEmulatedCapacitorOverCurrentSamples
+		e.I.faultPosSeqMag = e.I.PosSeqMag * 0.01
+		e.I.faultRemainingSamples = MaxEmulatedCapacitorOverCurrentSamples
 	default:
 	}
 }

--- a/threephase.go
+++ b/threephase.go
@@ -41,7 +41,7 @@ type ThreePhaseEmulation struct {
 	posSeqMagRampRate float64
 
 	// outputs
-	A, B, C float64
+	A, B, C float64 `yaml:"-"`
 }
 
 // Steps the three phase emulation forward by one time step. The new values are

--- a/threephase.go
+++ b/threephase.go
@@ -12,7 +12,7 @@ const TwoPiOverThree = 2 * math.Pi / 3
 
 type ThreePhaseEmulation struct {
 	// inputs
-	PosSeqMag       float64   `yaml:"PosSeqMag"`                      // positive sequence magnitude
+	PosSeqMag       float64   `yaml:"PosSeqMag,omitempty"`            // positive sequence magnitude
 	PhaseOffset     float64   `yaml:"PhaseOffset,omitempty"`          // phase offset
 	NegSeqMag       float64   `yaml:"NegSeqMag,omitempty"`            // negative sequence magnitude
 	NegSeqAng       float64   `yaml:"NegSeqAng,omitempty"`            // negative sequence angle
@@ -24,11 +24,11 @@ type ThreePhaseEmulation struct {
 	NoiseMag        float64   `yaml:"NoiseMag,omitempty"`             // magnitude of Gaussian noise
 
 	// define anomalies
-	PosSeqMagAnomaly anomaly.Container // positive sequence magnitude anomalies
-	PosSeqAngAnomaly anomaly.Container // positive sequence angle anomalies
-	PhaseAMagAnomaly anomaly.Container // phase A magnitude anomalies
-	FreqAnomaly      anomaly.Container // frequency anomalies
-	HarmonicsAnomaly anomaly.Container // harmonics magnitude anomalies
+	PosSeqMagAnomaly anomaly.Container `yaml:"PosSeqMagAnomaly,omitempty"` // positive sequence magnitude anomalies
+	PosSeqAngAnomaly anomaly.Container `yaml:"PosSeqAngAnomaly,omitempty"` // positive sequence angle anomalies
+	PhaseAMagAnomaly anomaly.Container `yaml:"PhaseAMagAnomaly,omitempty"` // phase A magnitude anomalies
+	FreqAnomaly      anomaly.Container `yaml:"FreqAnomaly,omitempty"`      // frequency anomalies
+	HarmonicsAnomaly anomaly.Container `yaml:"HarmonicsAnomaly,omitempty"` // harmonics anomalies
 
 	// event emulation
 	FaultPhaseAMag        float64 `yaml:"-"`

--- a/threephase.go
+++ b/threephase.go
@@ -31,19 +31,17 @@ type ThreePhaseEmulation struct {
 	HarmonicsAnomaly anomaly.Container `yaml:"HarmonicsAnomaly,omitempty"` // harmonics anomalies
 
 	// event emulation
-	FaultPhaseAMag        float64 `yaml:"-"`
-	FaultPosSeqMag        float64 `yaml:"-"`
-	FaultRemainingSamples int     `yaml:"-"`
+	faultPhaseAMag        float64
+	faultPosSeqMag        float64
+	faultRemainingSamples int
 
-	// state change
-	PosSeqMagNew      float64 `yaml:"-"`
-	PosSeqMagRampRate float64 `yaml:"-"`
-
-	// internal state
-	pAngle float64 `yaml:"-"`
+	// internal state, state change
+	pAngle            float64
+	posSeqMagNew      float64
+	posSeqMagRampRate float64
 
 	// outputs
-	A, B, C float64 `yaml:"-"`
+	A, B, C float64
 }
 
 // Steps the three phase emulation forward by one time step. The new values are
@@ -62,15 +60,15 @@ func (e *ThreePhaseEmulation) stepThreePhase(r *rand.Rand, f float64, Ts float64
 
 	PosSeqPhase := e.PhaseOffset + e.pAngle + (math.Pi * totalAnomalyDeltaPosSeqAng / 180.0)
 
-	if math.Abs(e.PosSeqMagNew-e.PosSeqMag) >= math.Abs(e.PosSeqMagRampRate) {
-		e.PosSeqMag = e.PosSeqMag + e.PosSeqMagRampRate
+	if math.Abs(e.posSeqMagNew-e.PosSeqMag) >= math.Abs(e.posSeqMagRampRate) {
+		e.PosSeqMag = e.PosSeqMag + e.posSeqMagRampRate
 	}
 
 	posSeqMag := e.PosSeqMag
 	// phaseAMag := e.PosSeqMag
-	if /*smpCnt > EmulatedFaultStartSamples && */ e.FaultRemainingSamples > 0 {
-		posSeqMag = posSeqMag + e.FaultPosSeqMag
-		e.FaultRemainingSamples--
+	if /*smpCnt > EmulatedFaultStartSamples && */ e.faultRemainingSamples > 0 {
+		posSeqMag = posSeqMag + e.faultPosSeqMag
+		e.faultRemainingSamples--
 	}
 
 	// positive sequence magnitude anomaly


### PR DESCRIPTION
Small tweak to update yaml tags on anomaly structs.

The event emulation options under the `ThreePhaseEmulation` struct still have blank tags because I'm not sure what they're for or if they're used? If they need to be set via yaml then let me know and I'll give them tags too.