### PR TITLE
Anomaly performance

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,0 +1,40 @@
+name: Go Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -21,20 +21,3 @@ jobs:
 
       - name: Run tests
         run: go test ./...
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
-          args: --timeout=5m

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ phaseOffsetDeg := 0.0
 // define some anomalies
 // spikes of magnitude +/- 30.0, triggering with probability 1% at each time step
 spikes, _ := anomaly.NewSpikeAnomaly(anomaly.SpikeParams{
+    Name:        "1pSpikes"
     Probability: 0.01,
     Magnitude:   30.0,
 })
@@ -26,6 +27,7 @@ spikes, _ := anomaly.NewSpikeAnomaly(anomaly.SpikeParams{
 // a repeating linear ramp
 ramp, _ := anomaly.NewTrendAnomaly(
     anomaly.TrendParams{
+        Name: "RepeatingLinear"
         Magnitude:   5, // ramp magnitude
         Duration:    0.7, // ramp duration, seconds
         MagFuncName: "linear",
@@ -51,15 +53,15 @@ emu.I = &emulator.ThreePhaseEmulation{
     HarmonicAngs:    []float64{171.5, 100.4, -52.4, 128.3, 80.0, 2.9, -146.8, 133.9},
     NoiseMag:        0.000001,
     PhaseAMagAnomaly: anomaly.Container{
-        "events": spikes,
+        spikes,
     },
 }
 
 // Create an anomaly container for temperature and add anomalies
 container := anomaly.Container{}
 spikes.Magnitude = 1.0 // re-use an anomaly with reduced magnitude
-_ = container.AddAnomaly(spikes) // returns uuid of anomaly
-_ = container.AddAnomaly(ramp)
+err := container.AddAnomaly(spikes)
+err := container.AddAnomaly(ramp)
 
 // Specify tempertaure parameters
 emu.T = &emulator.TemperatureEmulation{
@@ -92,12 +94,12 @@ where `foo.yml` is e.g.:
 MeanTemperature: 20.0
 NoiseMag: 0.1
 Anomaly:
-  repeating_ramp:   # anomaly name
-    Type: trend     # type of anomaly: trend
-    Magnitude: 5    # params
+  - Name: repeating_ramp # anomaly name
+    Type: trend # type of anomaly: trend
+    Magnitude: 5 # params
     Duration: 0.7
-  blips:            # anomaly name
-    Type: spike     # type of anomaly: spike
+  - Name: blips # anomaly name
+    Type: spike # type of anomaly: spike
     Probability: 0.01
     Magnitude: 2
   # etc
@@ -106,6 +108,7 @@ Anomaly:
 ## Anomalies
 
 Two types of anomaly can be added to the data to create interesting scenarios:
+
 1. Spike: actuate an instantaneous change of given magnitude to the selected parameter with a probability factor
 2. Trend: apply continuous changes to the parameter
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ spikes.Magnitude = 1.0 // re-use an anomaly with reduced magnitude
 err := container.AddAnomaly(spikes)
 err := container.AddAnomaly(ramp)
 
-// Specify tempertaure parameters
+// Specify temperature parameters
 emu.T = &emulator.TemperatureEmulation{
     MeanTemperature: 30.0,
     NoiseMag:        0.01,

--- a/anomaly/anomaly.go
+++ b/anomaly/anomaly.go
@@ -113,11 +113,21 @@ func (c *Container) AddAnomaly(anomaly AnomalyInterface) error {
 }
 
 // GetAnomalyByName returns the first anomaly in the container with the specified name, or nil if not found.
-func (c Container) GetAnomalyByName(name string) AnomalyInterface {
+func (c Container) GetAnomalyByName(name string) *AnomalyInterface {
 	for _, anomaly := range c {
 		if anomaly.GetName() == name {
-			return anomaly
+			return &anomaly
 		}
 	}
 	return nil
+}
+
+func (c Container) UpdateAnomalyByName(name string, newAnomaly AnomalyInterface) error {
+	for i, anomaly := range c {
+		if anomaly.GetName() == name && anomaly.GetTypeAsString() == newAnomaly.GetTypeAsString() {
+			c[i] = newAnomaly
+			return nil
+		}
+	}
+	return fmt.Errorf("anomaly with name %s and type %s not found", name, newAnomaly.GetTypeAsString())
 }

--- a/anomaly/anomaly.go
+++ b/anomaly/anomaly.go
@@ -50,26 +50,27 @@ func (c *Container) UnmarshalYAML(unmarshal func(any) error) error {
 		*c = make(Container, 0)
 	}
 
-	var raw map[string]any
+	var raw []map[string]any
 	if err := unmarshal(&raw); err != nil {
 		return err
 	}
+
 	var anomaly AnomalyInterface
 
 	// Match on the definition of the anomaly type
-	for key, value := range raw {
-		var anomaly AnomalyInterface
-		switch value["Type"].(string) {
-		case "spike":
-			anomaly = &spikeAnomaly{}
-		case "trend":
-			anomaly = &trendAnomaly{}
-		default:
-			return fmt.Errorf("unknown anomaly type: %s", value["Type"].(string))
+	for _, anomalyEntry := range raw {
+		if anomalyEntry["Type"] != nil {
+			switch anomalyEntry["Type"] {
+			case "spike":
+				anomaly = &spikeAnomaly{}
+			case "trend":
+				anomaly = &trendAnomaly{}
+			default:
+				return fmt.Errorf("unknown anomaly type: %s", anomalyEntry["Type"])
+			}
 		}
-
 		// Convert the value map into YAML for unmarshalling into an anomaly
-		valueYAML, err := yaml.Marshal(value)
+		valueYAML, err := yaml.Marshal(anomalyEntry)
 		if err != nil {
 			return err
 		}
@@ -79,7 +80,6 @@ func (c *Container) UnmarshalYAML(unmarshal func(any) error) error {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/anomaly/anomaly.go
+++ b/anomaly/anomaly.go
@@ -79,6 +79,8 @@ func (c *Container) UnmarshalYAML(unmarshal func(any) error) error {
 		if err := yaml.Unmarshal(valueYAML, anomaly); err != nil {
 			return err
 		}
+
+		c.AddAnomaly(anomaly)
 	}
 	return nil
 }

--- a/anomaly/anomaly_test.go
+++ b/anomaly/anomaly_test.go
@@ -5,9 +5,9 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/synaptecltd/emulator/anomaly"
-	"gopkg.in/yaml.v3"
 )
 
 // Test anomalies can be unmarshalled from yaml
@@ -27,7 +27,7 @@ inst1:
 `,
 		startDelay, duration, probability)
 
-	container := make(anomaly.Container)
+	container := make(anomaly.Container, 0)
 	err := yaml.Unmarshal([]byte(yamlStr), &container)
 	assert.NoError(t, err)
 

--- a/anomaly/anomaly_test.go
+++ b/anomaly/anomaly_test.go
@@ -55,6 +55,16 @@ func TestUnmarshalYAML(t *testing.T) {
 	}
 }
 
+func TestUnmarshalYAMLUnknownType(t *testing.T) {
+	yamlStr := `
+- Type: NotARealType
+  SomeField: 1.0
+`
+	var container anomaly.Container
+	err := yaml.Unmarshal([]byte(yamlStr), &container)
+	assert.Error(t, err)
+}
+
 // Get type of anomaly as string
 func TestGetTypeAsString(t *testing.T) {
 	instAnomaly, _ := anomaly.NewSpikeAnomaly(anomaly.SpikeParams{})

--- a/anomaly/anomaly_test.go
+++ b/anomaly/anomaly_test.go
@@ -17,17 +17,15 @@ func TestUnmarshalYAML(t *testing.T) {
 	probability := rand.Float64()
 
 	yamlStr := fmt.Sprintf(`
-trend1:
-  Type: trend
+- Type: trend
   StartDelay: %f
   Duration: %f
-inst1:
-  Type: spike
+- Type: spike
   Probability: %f
 `,
 		startDelay, duration, probability)
 
-	container := make(anomaly.Container, 0)
+	var container anomaly.Container
 	err := yaml.Unmarshal([]byte(yamlStr), &container)
 	assert.NoError(t, err)
 

--- a/anomaly/anomaly_test.go
+++ b/anomaly/anomaly_test.go
@@ -20,8 +20,10 @@ func TestUnmarshalYAML(t *testing.T) {
 - Type: trend
   StartDelay: %f
   Duration: %f
+  Name: Trend Anomaly
 - Type: spike
   Probability: %f
+  Name: Spike Anomaly
 `,
 		startDelay, duration, probability)
 
@@ -59,6 +61,21 @@ func TestUnmarshalYAMLUnknownType(t *testing.T) {
 	yamlStr := `
 - Type: NotARealType
   SomeField: 1.0
+`
+	var container anomaly.Container
+	err := yaml.Unmarshal([]byte(yamlStr), &container)
+	assert.Error(t, err)
+}
+
+func TestUnmarshalYAMLDuplicateName(t *testing.T) {
+	yamlStr := `
+- Type: trend
+  StartDelay: 1.0
+  Duration: 2.0
+  Name: Trend Anomaly
+- Type: spike
+  Probability: 0.5
+  Name: Trend Anomaly
 `
 	var container anomaly.Container
 	err := yaml.Unmarshal([]byte(yamlStr), &container)

--- a/anomaly/anomalybase.go
+++ b/anomaly/anomalybase.go
@@ -10,6 +10,7 @@ import (
 type AnomalyBase struct {
 	Repeats uint64 // the number of times the anomalies repeat, 0 for infinite
 	Off     bool   // true: anomaly deactivated, false: activated
+	name    string // name of the anomaly, used for identification
 
 	// Setters with error checking should be provided for private fields below
 	typeName   string  // the type of anomaly as a string, e.g. "trend", "spike".
@@ -22,6 +23,10 @@ type AnomalyBase struct {
 	elapsedActivatedIndex int     // number of time steps since start of this active anomaly repeat, used to track the progress within an anomaly burst/trend
 	elapsedActivatedTime  float64 // time elapsed since the start of this active anomaly repeat
 	countRepeats          uint64  // counter for number of times the anomaly trend/burst has repeated
+}
+
+func (a *AnomalyBase) GetName() string {
+	return a.name
 }
 
 // Returns the type of anomaly as a string.

--- a/anomaly/spike.go
+++ b/anomaly/spike.go
@@ -31,6 +31,7 @@ type spikeAnomaly struct {
 type SpikeParams struct {
 	// Defined in AnomalyBase
 
+	Name       string  `yaml:"Name"`       // name of the anomaly, used for identification
 	Repeats    uint64  `yaml:"Repeats"`    // the number of times spike bursts repeat, 0 for infinite
 	Off        bool    `yaml:"Off"`        // true: anomaly deactivated, false: activated
 	StartDelay float64 `yaml:"StartDelay"` // the delay before spike bursts begin (and time between bursts) in seconds
@@ -69,6 +70,8 @@ func (s *spikeAnomaly) UnmarshalYAML(unmarshal func(any) error) error {
 // Returns a spikeAnomaly pointer with the requested parameters, checking for invalid values.
 func NewSpikeAnomaly(params SpikeParams) (*spikeAnomaly, error) {
 	spikeAnomaly := &spikeAnomaly{}
+
+	spikeAnomaly.name = params.Name
 
 	// Invalid values checked by setters
 	if err := spikeAnomaly.SetStartDelay(params.StartDelay); err != nil {

--- a/anomaly/spike.go
+++ b/anomaly/spike.go
@@ -100,7 +100,7 @@ func NewSpikeAnomaly(params SpikeParams) (*spikeAnomaly, error) {
 	return spikeAnomaly, nil
 }
 
-// Returns the change in signal caused by the instantaneous anomaly this timestep.
+// stepAnomaly returns the change in signal caused by the instantaneous anomaly this timestep.
 func (s *spikeAnomaly) stepAnomaly(r *rand.Rand, Ts float64) float64 {
 	if s.Off {
 		return 0.0

--- a/anomaly/trend.go
+++ b/anomaly/trend.go
@@ -23,6 +23,7 @@ type trendAnomaly struct {
 type TrendParams struct {
 	// Defined in AnomalyBase
 
+	Name       string  `yaml:"Name"`       // name of the anomaly, used for identification
 	Repeats    uint64  `yaml:"Repeats"`    // the number of times the trend anomaly repeats, 0 for infinite
 	Off        bool    `yaml:"Off"`        // true: anomaly deactivated, false: activated
 	StartDelay float64 `yaml:"StartDelay"` // the delay before trend anomalies begin (and between anomaly repeats) in seconds
@@ -57,6 +58,8 @@ func (t *trendAnomaly) UnmarshalYAML(unmarshal func(any) error) error {
 // Returns a trendAnomaly pointer with the requested parameters, checking for invalid values.
 func NewTrendAnomaly(params TrendParams) (*trendAnomaly, error) {
 	trendAnomaly := &trendAnomaly{}
+
+	trendAnomaly.name = params.Name
 
 	// Invalid values checked by setters
 	if err := trendAnomaly.SetDuration(params.Duration); err != nil {

--- a/anomaly/trend.go
+++ b/anomaly/trend.go
@@ -79,7 +79,7 @@ func NewTrendAnomaly(params TrendParams) (*trendAnomaly, error) {
 	return trendAnomaly, nil
 }
 
-// Returns the change in signal caused by the trend anomaly this timestep.
+// stepAnomaly returns the change in signal caused by the trend anomaly this timestep.
 // Manages internal indices to track the progress of trend cycles, and delays between trend cycles.
 // Ts is the sampling period of the data.
 func (t *trendAnomaly) stepAnomaly(_ *rand.Rand, Ts float64) float64 {

--- a/emulator_test.go
+++ b/emulator_test.go
@@ -67,7 +67,7 @@ func TestTemperatureEmulationAnomalies_NoAnomalies(t *testing.T) {
 		MeanTemperature: 30.0,
 		NoiseMag:        0.01,
 		Anomaly: anomaly.Container{
-			anomalyKey: spikeAnomaly,
+			spikeAnomaly,
 		},
 	}
 
@@ -75,7 +75,7 @@ func TestTemperatureEmulationAnomalies_NoAnomalies(t *testing.T) {
 	var results []bool
 	for step < 1e4 {
 		emulator.Step()
-		results = append(results, emulator.T.Anomaly[anomalyKey].GetIsAnomalyActive())
+		results = append(results, emulator.T.Anomaly[0].GetIsAnomalyActive())
 		step += 1
 	}
 	assert.NotContains(t, results, true)
@@ -99,7 +99,7 @@ func TestTemperatureEmulationAnomalies_Anomalies(t *testing.T) {
 		MeanTemperature: 30.0,
 		NoiseMag:        0.01,
 		Anomaly: anomaly.Container{
-			anomalyKey: spikeAnomaly,
+			spikeAnomaly,
 		},
 	}
 
@@ -109,9 +109,9 @@ func TestTemperatureEmulationAnomalies_Anomalies(t *testing.T) {
 	var anomalyValues []float64
 	for step < 1e4 {
 		emulator.Step()
-		results = append(results, emulator.T.Anomaly[anomalyKey].GetIsAnomalyActive())
+		results = append(results, emulator.T.Anomaly[0].GetIsAnomalyActive())
 
-		if emulator.T.Anomaly[anomalyKey].GetIsAnomalyActive() == true {
+		if emulator.T.Anomaly[0].GetIsAnomalyActive() == true {
 			anomalyValues = append(anomalyValues, emulator.T.T)
 		} else {
 			normalValues = append(normalValues, emulator.T.T)
@@ -142,7 +142,7 @@ func TestTemperatureEmulationAnomalies_RisingTrend(t *testing.T) {
 		MeanTemperature: 30.0,
 		NoiseMag:        0.01,
 		Anomaly: anomaly.Container{
-			anomalyKey: trendAnomaly,
+			trendAnomaly,
 		},
 	}
 
@@ -176,7 +176,7 @@ func TestTemperatureEmulationAnomalies_DecreasingTrend(t *testing.T) {
 		MeanTemperature: 30.0,
 		NoiseMag:        0.01,
 		Anomaly: anomaly.Container{
-			anomalyKey: trendAnomaly,
+			trendAnomaly,
 		},
 	}
 
@@ -207,7 +207,7 @@ func TestCurrentPosSeqAnomalies_RisingTrend(t *testing.T) {
 		PosSeqMag:   350.0,
 		PhaseOffset: 0.0,
 		PosSeqMagAnomaly: anomaly.Container{
-			anomalyKey: trendAnomaly,
+			trendAnomaly,
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,15 @@ module github.com/synaptecltd/emulator
 go 1.24
 
 require (
-	github.com/google/uuid v1.6.0
+	github.com/goccy/go-yaml v1.18.0
 	github.com/stevenblair/sigourney v0.0.0-20230226010226-466bed07c980
 	github.com/stretchr/testify v1.8.1
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 retract v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stevenblair/sigourney v0.0.0-20230226010226-466bed07c980 h1:m6psilIRNRNO3L5DNHO1opQuFodvXVsCBGtWDudNVbM=

--- a/temperature.go
+++ b/temperature.go
@@ -3,7 +3,6 @@ package emulator
 import (
 	"math/rand/v2"
 
-	"github.com/google/uuid"
 	"github.com/synaptecltd/emulator/anomaly"
 )
 
@@ -23,7 +22,7 @@ func (t *TemperatureEmulation) stepTemperature(r *rand.Rand, Ts float64) {
 	t.T += anomalyValues
 }
 
-// Add an anomaly to the temperature emulation, returning the UUID of the added anomaly.
-func (t *TemperatureEmulation) AddAnomaly(anom anomaly.AnomalyInterface) uuid.UUID {
-	return t.Anomaly.AddAnomaly(anom)
+// Add an anomaly to the temperature emulation.
+func (t *TemperatureEmulation) AddAnomaly(anom anomaly.AnomalyInterface) {
+	t.Anomaly.AddAnomaly(anom)
 }


### PR DESCRIPTION
This has a few small changes around the performance improvements.

This will now run CI tests on PRs.

The yaml library has been changed to goccy's go-yaml, as [go-yaml/yaml](https://github.com/go-yaml/yaml) is unmaintained now. That's the [gopkg.in/yaml.v3](gopkg.in/yaml.v3).

The `anomaly.Container` is now a collection which fixes the performance issues caused by the map iterator. The remainder of the changes support this, including adding a name field to allow similar map behaviour but not at the expense of `step()` performance