### PR TITLE
Adding argument to reverse trend of anomaly, allowing for more varied signal shapes

### DIFF
--- a/anomaly/anomaly_test.go
+++ b/anomaly/anomaly_test.go
@@ -189,3 +189,31 @@ func TestUpdateAnomalyByNameChangeType(t *testing.T) {
 	err := container.UpdateAnomalyByName("TestAnomaly", spikeAnomaly)
 	assert.Error(t, err)
 }
+
+// Checking reverse trend paramater functions as intended
+func TestReverseTrend(t *testing.T) {
+	container := anomaly.Container{}
+	params := anomaly.TrendParams{
+		Name:         "ReverseTrendTest",
+		StartDelay:   0.0,
+		Duration:     5.0,
+		Magnitude:    10.0,
+		Repeats:      1,
+		InvertTrend:  false,
+		ReverseTrend: true,
+		Off:          false,
+	}
+
+	trendAnomaly, err := anomaly.NewTrendAnomaly(params)
+	assert.NoError(t, err)
+	container.AddAnomaly(trendAnomaly)
+
+	Ts := 1.0 // time step of 1 second
+	rng := rand.New(rand.NewPCG(42, 0))
+	expectedValues := []float64{10.0, 8.0, 6.0, 4.0, 2.0}
+
+	for i, expected := range expectedValues {
+		value := container.StepAll(rng, Ts)
+		assert.InDelta(t, expected, value, 1e-6, "At step %d", i)
+	}
+}

--- a/anomaly/anomaly_test.go
+++ b/anomaly/anomaly_test.go
@@ -189,31 +189,3 @@ func TestUpdateAnomalyByNameChangeType(t *testing.T) {
 	err := container.UpdateAnomalyByName("TestAnomaly", spikeAnomaly)
 	assert.Error(t, err)
 }
-
-// Checking reverse trend paramater functions as intended
-func TestReverseTrend(t *testing.T) {
-	container := anomaly.Container{}
-	params := anomaly.TrendParams{
-		Name:         "ReverseTrendTest",
-		StartDelay:   0.0,
-		Duration:     5.0,
-		Magnitude:    10.0,
-		Repeats:      1,
-		InvertTrend:  false,
-		ReverseTrend: true,
-		Off:          false,
-	}
-
-	trendAnomaly, err := anomaly.NewTrendAnomaly(params)
-	assert.NoError(t, err)
-	container.AddAnomaly(trendAnomaly)
-
-	Ts := 1.0 // time step of 1 second
-	rng := rand.New(rand.NewPCG(42, 0))
-	expectedValues := []float64{10.0, 8.0, 6.0, 4.0, 2.0}
-
-	for i, expected := range expectedValues {
-		value := container.StepAll(rng, Ts)
-		assert.InDelta(t, expected, value, 1e-6, "At step %d", i)
-	}
-}

--- a/anomaly/trend.go
+++ b/anomaly/trend.go
@@ -80,13 +80,8 @@ func NewTrendAnomaly(params TrendParams) (*trendAnomaly, error) {
 	trendAnomaly.Repeats = params.Repeats
 	trendAnomaly.InvertTrend = params.InvertTrend
 	trendAnomaly.ReverseTrend = params.ReverseTrend
+	trendAnomaly.Off = params.Off
 
-	// Set Off based on duration
-	if trendAnomaly.duration == 0 {
-		trendAnomaly.Off = true
-	} else {
-		trendAnomaly.Off = params.Off
-	}
 	return trendAnomaly, nil
 }
 

--- a/anomaly/trend.go
+++ b/anomaly/trend.go
@@ -79,8 +79,14 @@ func NewTrendAnomaly(params TrendParams) (*trendAnomaly, error) {
 	trendAnomaly.Magnitude = params.Magnitude
 	trendAnomaly.Repeats = params.Repeats
 	trendAnomaly.InvertTrend = params.InvertTrend
-	trendAnomaly.Off = params.Off
+	trendAnomaly.ReverseTrend = params.ReverseTrend
 
+	// Set Off based on duration
+	if trendAnomaly.duration == 0 {
+		trendAnomaly.Off = true
+	} else {
+		trendAnomaly.Off = params.Off
+	}
 	return trendAnomaly, nil
 }
 

--- a/anomaly/trend.go
+++ b/anomaly/trend.go
@@ -11,9 +11,10 @@ import (
 type trendAnomaly struct {
 	AnomalyBase
 
-	Magnitude   float64 // magnitude of trend anomaly, default 0
-	magFuncName string  // name of function to use to vary the trend magnitude, defaults to "linear" if empty
-	InvertTrend bool    // true inverts the trend function (multiplies by -1.0), default false (no inverting)
+	Magnitude    float64 // magnitude of trend anomaly, default 0
+	magFuncName  string  // name of function to use to vary the trend magnitude, defaults to "linear" if empty
+	InvertTrend  bool    // true inverts the trend function (multiplies by -1.0), default false (no inverting)
+	ReverseTrend bool    // true subtracts the original value by 'Magnitude' (equivalent of reversing along horizontal axis)
 
 	// internal state
 	magFunction mathfuncs.MathsFunction // returns trend anomaly magnitude for a given elapsed time, magntiude and period; set internally from TrendFuncName
@@ -31,9 +32,10 @@ type TrendParams struct {
 
 	// Defined in trendAnomaly
 
-	Magnitude   float64 `yaml:"Magnitude"` // magnitude of trend anomaly, default 0
-	MagFuncName string  `yaml:"MagFunc"`   // name of the function used to vary the magnitude of the trend anomaly, empty defaults to "linear"
-	InvertTrend bool    `yaml:"Invert"`    // true inverts the trend function (multiplies by -1.0), default false (no inverting)
+	Magnitude    float64 `yaml:"Magnitude"` // magnitude of trend anomaly, default 0
+	MagFuncName  string  `yaml:"MagFunc"`   // name of the function used to vary the magnitude of the trend anomaly, empty defaults to "linear"
+	InvertTrend  bool    `yaml:"Invert"`    // true inverts the trend function (multiplies by -1.0), default false (no inverting)
+	ReverseTrend bool    `yaml:"Reverse"`   // true subtracts the original value by 'Magnitude' (equivalent of reversing along horizontal axis)
 }
 
 // Initialise the internal fields of TrendAnomaly when it is unmarshalled from yaml.
@@ -102,6 +104,9 @@ func (t *trendAnomaly) stepAnomaly(_ *rand.Rand, Ts float64) float64 {
 
 	trendAnomalyMagnitude := t.magFunction(t.elapsedActivatedTime, t.Magnitude, t.duration)
 	trendAnomalyDelta := t.getSign() * trendAnomalyMagnitude
+	if t.ReverseTrend {
+		trendAnomalyDelta = t.Magnitude - trendAnomalyMagnitude
+	}
 
 	// If the trend anomaly is complete, reset the index and increment the repeat counter
 	if t.elapsedActivatedIndex == int(t.duration/Ts) {

--- a/anomaly/trend.go
+++ b/anomaly/trend.go
@@ -104,9 +104,18 @@ func (t *trendAnomaly) stepAnomaly(_ *rand.Rand, Ts float64) float64 {
 	t.elapsedActivatedIndex += 1
 
 	trendAnomalyMagnitude := t.magFunction(t.elapsedActivatedTime, t.Magnitude, t.duration)
-	trendAnomalyDelta := t.getSign() * trendAnomalyMagnitude
-	if t.ReverseTrend {
+
+	// Once we have the magnitude, apply inverting or reversing if required
+	var trendAnomalyDelta float64
+	switch {
+	case t.ReverseTrend && t.InvertTrend: // both true
+		trendAnomalyDelta = -(t.Magnitude - trendAnomalyMagnitude)
+	case t.ReverseTrend: // only reverse true
 		trendAnomalyDelta = t.Magnitude - trendAnomalyMagnitude
+	case t.InvertTrend: // only invert true
+		trendAnomalyDelta = -trendAnomalyMagnitude
+	default: // both false
+		trendAnomalyDelta = trendAnomalyMagnitude
 	}
 
 	// If the trend anomaly is complete, reset the index and increment the repeat counter
@@ -117,14 +126,6 @@ func (t *trendAnomaly) stepAnomaly(_ *rand.Rand, Ts float64) float64 {
 	}
 
 	return trendAnomalyDelta
-}
-
-// Returns -1.0 if InvertTrend is true, or +1.0 if false.
-func (t *trendAnomaly) getSign() float64 {
-	if t.InvertTrend {
-		return -1.0
-	}
-	return 1.0
 }
 
 // Setters

--- a/anomaly/trend_test.go
+++ b/anomaly/trend_test.go
@@ -1,0 +1,53 @@
+package anomaly
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReverseInvertTrend(t *testing.T) {
+	type testcase struct {
+		InvertTrend  bool
+		ReverseTrend bool
+		Expected     []float64
+	}
+
+	testcases := []testcase{
+		{InvertTrend: false, ReverseTrend: false, Expected: []float64{0.0, 2.0, 4.0, 6.0, 8.0}},
+		{InvertTrend: true, ReverseTrend: false, Expected: []float64{0.0, -2.0, -4.0, -6.0, -8.0}},
+		{InvertTrend: false, ReverseTrend: true, Expected: []float64{10.0, 8.0, 6.0, 4.0, 2.0}},
+		{InvertTrend: true, ReverseTrend: true, Expected: []float64{-10.0, -8.0, -6.0, -4.0, -2.0}},
+	}
+
+	Ts := 1.0 // 1 second time step
+	rng := rand.New(rand.NewPCG(42, 0))
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("InvertTrend:%v-ReverseTrend:%v", tc.InvertTrend, tc.ReverseTrend), func(t *testing.T) {
+			params := TrendParams{
+				Name:         "ReverseInvertTrendTest",
+				StartDelay:   0.0,
+				Duration:     5.0,
+				Magnitude:    10.0,
+				InvertTrend:  tc.InvertTrend,
+				ReverseTrend: tc.ReverseTrend,
+				Off:          false,
+			}
+
+			trendAnomaly, err := NewTrendAnomaly(params)
+			assert.NoError(t, err)
+
+			for i, expected := range tc.Expected {
+				value := trendAnomaly.stepAnomaly(rng, Ts)
+				assert.InDelta(t, expected, value, 1e-6, "At step %d with InvertTrend=%v ReverseTrend=%v", i, tc.InvertTrend, tc.ReverseTrend)
+			}
+			for i, expected := range tc.Expected {
+				value := trendAnomaly.stepAnomaly(rng, Ts)
+				assert.InDelta(t, expected, value, 1e-6, "Post-duration step %d with InvertTrend=%v ReverseTrend=%v", i, tc.InvertTrend, tc.ReverseTrend)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding an arugment to the trend anomaly struct of reverse trend. This will return the magnitude subtracted  by the calculated delta if set to True. This can allow for more wave patterns (mainly ones that decrease over time, but stay positive)