### PR TITLE
updates to trend functionality and yaml parser

### DIFF
--- a/anomaly/spike.go
+++ b/anomaly/spike.go
@@ -76,7 +76,13 @@ func (s *spikeAnomaly) UnmarshalYAML(unmarshal func(any) error) error {
 func NewSpikeAnomaly(params SpikeParams) (*spikeAnomaly, error) {
 	spikeAnomaly := &spikeAnomaly{}
 
+	// Fields that can never be invalid set directly
 	spikeAnomaly.name = params.Name
+	spikeAnomaly.typeName = "spike"
+	spikeAnomaly.Magnitude = params.Magnitude
+	spikeAnomaly.VaryMagnitude = params.VaryMagnitude
+	spikeAnomaly.Repeats = params.Repeats
+	spikeAnomaly.Off = params.Off
 
 	// Invalid values checked by setters
 	if err := spikeAnomaly.SetStartDelay(params.StartDelay); err != nil {
@@ -97,13 +103,6 @@ func NewSpikeAnomaly(params SpikeParams) (*spikeAnomaly, error) {
 	if err := spikeAnomaly.SetDuration(params.Duration); err != nil {
 		return nil, err
 	}
-
-	// Fields that can never be invalid set directly
-	spikeAnomaly.typeName = "spike"
-	spikeAnomaly.Magnitude = params.Magnitude
-	spikeAnomaly.VaryMagnitude = params.VaryMagnitude
-	spikeAnomaly.Repeats = params.Repeats
-	spikeAnomaly.Off = params.Off
 
 	return spikeAnomaly, nil
 }
@@ -186,7 +185,7 @@ func (s *spikeAnomaly) getSign(r *rand.Rand) float64 {
 func (s *spikeAnomaly) SetDuration(duration float64) error {
 	if duration == 0 {
 		if s.magFunction != nil {
-			return errors.New("duration must be greater than 0 when using a functional dependence for magntiude")
+			return errors.New("duration must be greater than 0 when using a functional dependence for magnitude")
 		}
 		duration = -1.0 // continuous burst
 	}

--- a/anomaly/spike.go
+++ b/anomaly/spike.go
@@ -48,6 +48,11 @@ type SpikeParams struct {
 	ProbFuncName string  `yaml:"ProbFunc"`    // name of the function used to vary the probability of the spikes, empty defaults to constant =probability
 }
 
+// Helper function redirecting back to decodeStrict using correct type
+func (s *spikeAnomaly) UnmarshalYAMLBytes(data []byte) error {
+	return decodeStrict(data, s)
+}
+
 // Initialise the internal fields of SpikeAnomaly when it is unmarshalled from yaml.
 func (s *spikeAnomaly) UnmarshalYAML(unmarshal func(any) error) error {
 	var params SpikeParams

--- a/anomaly/trend.go
+++ b/anomaly/trend.go
@@ -68,7 +68,14 @@ func (t *trendAnomaly) UnmarshalYAML(unmarshal func(any) error) error {
 func NewTrendAnomaly(params TrendParams) (*trendAnomaly, error) {
 	trendAnomaly := &trendAnomaly{}
 
+	// Fields that can never be invalid set directly
 	trendAnomaly.name = params.Name
+	trendAnomaly.typeName = "trend"
+	trendAnomaly.Magnitude = params.Magnitude
+	trendAnomaly.Repeats = params.Repeats
+	trendAnomaly.InvertTrend = params.InvertTrend
+	trendAnomaly.ReverseTrend = params.ReverseTrend
+	trendAnomaly.Off = params.Off // This can overridden by SetDuration below
 
 	// Invalid values checked by setters
 	if err := trendAnomaly.SetDuration(params.Duration); err != nil {
@@ -83,14 +90,6 @@ func NewTrendAnomaly(params TrendParams) (*trendAnomaly, error) {
 	if err := trendAnomaly.SetPeriodDuration(params.PeriodDuration); err != nil {
 		return nil, err
 	}
-
-	// Fields that can never be invalid set directly
-	trendAnomaly.typeName = "trend"
-	trendAnomaly.Magnitude = params.Magnitude
-	trendAnomaly.Repeats = params.Repeats
-	trendAnomaly.InvertTrend = params.InvertTrend
-	trendAnomaly.ReverseTrend = params.ReverseTrend
-	trendAnomaly.Off = params.Off
 
 	return trendAnomaly, nil
 }

--- a/anomaly/trend.go
+++ b/anomaly/trend.go
@@ -14,28 +14,35 @@ type trendAnomaly struct {
 	Magnitude    float64 // magnitude of trend anomaly, default 0
 	magFuncName  string  // name of function to use to vary the trend magnitude, defaults to "linear" if empty
 	InvertTrend  bool    // true inverts the trend function (multiplies by -1.0), default false (no inverting)
-	ReverseTrend bool    // true subtracts the original value by 'Magnitude' (equivalent of reversing along horizontal axis)
+	ReverseTrend bool    // true subtracts the original value by 'Magnitude' (mimicking reversal along horizontal axis) - note can cause offset
 
 	// internal state
-	magFunction mathfuncs.MathsFunction // returns trend anomaly magnitude for a given elapsed time, magntiude and period; set internally from TrendFuncName
+	magFunction    mathfuncs.MathsFunction // returns trend anomaly magnitude for a given elapsed time, magntiude and period; set internally from TrendFuncName
+	periodDuration float64                 // duration of periods within the duration window, if 0, Duration is used as period.
 }
 
 // Parameters to use for the trend anomaly. All can be accessed publicly and used to define trendAnomaly.
 type TrendParams struct {
 	// Defined in AnomalyBase
 
-	Name       string  `yaml:"Name"`       // name of the anomaly, used for identification
-	Repeats    uint64  `yaml:"Repeats"`    // the number of times the trend anomaly repeats, 0 for infinite
-	Off        bool    `yaml:"Off"`        // true: anomaly deactivated, false: activated
-	StartDelay float64 `yaml:"StartDelay"` // the delay before trend anomalies begin (and between anomaly repeats) in seconds
-	Duration   float64 `yaml:"Duration"`   // the duration of each trend anomaly in seconds, 0 for continuous
+	Name           string  `yaml:"Name"`           // name of the anomaly, used for identification
+	Repeats        uint64  `yaml:"Repeats"`        // the number of times the trend anomaly repeats, 0 for infinite
+	Off            bool    `yaml:"Off"`            // true: anomaly deactivated, false: activated
+	StartDelay     float64 `yaml:"StartDelay"`     // the delay before trend anomalies begin (and between anomaly repeats) in seconds
+	Duration       float64 `yaml:"Duration"`       // the duration of each trend anomaly in seconds, 0 for continuous
+	PeriodDuration float64 `yaml:"PeriodDuration"` // duration of periods within the duration window, if 0, Duration is used as period.
 
 	// Defined in trendAnomaly
 
 	Magnitude    float64 `yaml:"Magnitude"` // magnitude of trend anomaly, default 0
 	MagFuncName  string  `yaml:"MagFunc"`   // name of the function used to vary the magnitude of the trend anomaly, empty defaults to "linear"
 	InvertTrend  bool    `yaml:"Invert"`    // true inverts the trend function (multiplies by -1.0), default false (no inverting)
-	ReverseTrend bool    `yaml:"Reverse"`   // true subtracts the original value by 'Magnitude' (equivalent of reversing along horizontal axis)
+	ReverseTrend bool    `yaml:"Reverse"`   // true subtracts the original value by 'Magnitude' (mimicking reversal along horizontal axis) - note can cause offset
+}
+
+// Helper function redirecting back to decodeStrict using correct type
+func (t *trendAnomaly) UnmarshalYAMLBytes(data []byte) error {
+	return decodeStrict(data, t)
 }
 
 // Initialise the internal fields of TrendAnomaly when it is unmarshalled from yaml.
@@ -73,6 +80,9 @@ func NewTrendAnomaly(params TrendParams) (*trendAnomaly, error) {
 	if err := trendAnomaly.SetMagFunctionByName(params.MagFuncName); err != nil {
 		return nil, err
 	}
+	if err := trendAnomaly.SetPeriodDuration(params.PeriodDuration); err != nil {
+		return nil, err
+	}
 
 	// Fields that can never be invalid set directly
 	trendAnomaly.typeName = "trend"
@@ -80,13 +90,7 @@ func NewTrendAnomaly(params TrendParams) (*trendAnomaly, error) {
 	trendAnomaly.Repeats = params.Repeats
 	trendAnomaly.InvertTrend = params.InvertTrend
 	trendAnomaly.ReverseTrend = params.ReverseTrend
-
-	if trendAnomaly.duration == 0 {
-		// This logic is also in SetDuration, but ensure it's set here too
-		trendAnomaly.Off = true
-	} else {
-		trendAnomaly.Off = params.Off
-	}
+	trendAnomaly.Off = params.Off
 
 	return trendAnomaly, nil
 }
@@ -109,7 +113,8 @@ func (t *trendAnomaly) stepAnomaly(_ *rand.Rand, Ts float64) float64 {
 	t.elapsedActivatedTime = float64(t.elapsedActivatedIndex) * Ts
 	t.elapsedActivatedIndex += 1
 
-	trendAnomalyMagnitude := t.magFunction(t.elapsedActivatedTime, t.Magnitude, t.duration)
+	// periodDuration is either Duration if it was originally set at 0, or user-defined value
+	trendAnomalyMagnitude := t.magFunction(t.elapsedActivatedTime, t.Magnitude, t.periodDuration)
 
 	// Once we have the magnitude, apply inverting or reversing if required
 	var trendAnomalyDelta float64
@@ -146,6 +151,20 @@ func (t *trendAnomaly) SetDuration(duration float64) error {
 		t.Off = true
 	}
 	t.duration = duration
+	return nil
+}
+
+// Sets the period duration for the signal during a trend anomaly in seconds if periodDuration >= 0.
+// If periodDuration=0, the duration of the trend anomaly is used as the period duration.
+func (t *trendAnomaly) SetPeriodDuration(periodDuration float64) error {
+	if periodDuration < 0 {
+		return errors.New("periodDuration must be positive value")
+	}
+	if periodDuration == 0 {
+		t.periodDuration = t.duration // defer to duration
+		return nil
+	}
+	t.periodDuration = periodDuration
 	return nil
 }
 

--- a/anomaly/trend_test.go
+++ b/anomaly/trend_test.go
@@ -105,7 +105,7 @@ func TestNewTrendAnomaly(t *testing.T) {
 
 		_, err := NewTrendAnomaly(params)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "duration must be positive")
+		assert.Contains(t, err.Error(), "duration must be positive value")
 	})
 
 	t.Run("InvalidStartDelay", func(t *testing.T) {


### PR DESCRIPTION
yaml parser:

 - Added strict decoding of yaml to raise error on unknown fields.

trend functionality:

 - Added note that reversetrend can cause offset depending on function. 
 - Added parameter of PeriodDuration, 
    - this is used in place of T for trendAnomaly maths functions if set. 
    - If it is not set (i.e. 0) it will use Duration. 

general:

 - Added and/or updated relevant test cases