### PR TITLE
yaml parser change and period duration added for trend anomaly

### DIFF
--- a/anomaly/spike.go
+++ b/anomaly/spike.go
@@ -48,6 +48,11 @@ type SpikeParams struct {
 	ProbFuncName string  `yaml:"ProbFunc"`    // name of the function used to vary the probability of the spikes, empty defaults to constant =probability
 }
 
+// Helper function redirecting back to decodeStrict using correct type
+func (s *spikeAnomaly) UnmarshalYAMLBytes(data []byte) error {
+	return decodeStrict(data, s)
+}
+
 // Initialise the internal fields of SpikeAnomaly when it is unmarshalled from yaml.
 func (s *spikeAnomaly) UnmarshalYAML(unmarshal func(any) error) error {
 	var params SpikeParams
@@ -71,7 +76,13 @@ func (s *spikeAnomaly) UnmarshalYAML(unmarshal func(any) error) error {
 func NewSpikeAnomaly(params SpikeParams) (*spikeAnomaly, error) {
 	spikeAnomaly := &spikeAnomaly{}
 
+	// Fields that can never be invalid set directly
 	spikeAnomaly.name = params.Name
+	spikeAnomaly.typeName = "spike"
+	spikeAnomaly.Magnitude = params.Magnitude
+	spikeAnomaly.VaryMagnitude = params.VaryMagnitude
+	spikeAnomaly.Repeats = params.Repeats
+	spikeAnomaly.Off = params.Off
 
 	// Invalid values checked by setters
 	if err := spikeAnomaly.SetStartDelay(params.StartDelay); err != nil {
@@ -92,13 +103,6 @@ func NewSpikeAnomaly(params SpikeParams) (*spikeAnomaly, error) {
 	if err := spikeAnomaly.SetDuration(params.Duration); err != nil {
 		return nil, err
 	}
-
-	// Fields that can never be invalid set directly
-	spikeAnomaly.typeName = "spike"
-	spikeAnomaly.Magnitude = params.Magnitude
-	spikeAnomaly.VaryMagnitude = params.VaryMagnitude
-	spikeAnomaly.Repeats = params.Repeats
-	spikeAnomaly.Off = params.Off
 
 	return spikeAnomaly, nil
 }

--- a/anomaly/trend_test.go
+++ b/anomaly/trend_test.go
@@ -105,7 +105,7 @@ func TestNewTrendAnomaly(t *testing.T) {
 
 		_, err := NewTrendAnomaly(params)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "duration must be positive")
+		assert.Contains(t, err.Error(), "duration must be positive value")
 	})
 
 	t.Run("InvalidStartDelay", func(t *testing.T) {


### PR DESCRIPTION
yaml parser:

 - Added strict decoding of yaml to raise error on unknown fields.
 
trend functionality:

- Added note that reversetrend can cause offset depending on function.
- Added parameter of PeriodDuration,
   - this is used in place of T for trendAnomaly maths functions if set.
   - If it is not set (i.e. 0) it will use Duration.

general:

- Added and/or updated relevant test cases